### PR TITLE
Output the name of the class explicitly in SpecReporter 

### DIFF
--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -32,7 +32,7 @@ module MiniTest
       end
       
       def before_suite(suite)
-        puts suite
+        puts suite.name
       end
       
       def after_suite(suite)


### PR DESCRIPTION
This solves a problem when running through a DRb server such as spork of
outputing `#<DRb::DRbUnknown:0x007ff87e126708>` instead of the intended class name.
