### PR TITLE
Fix for RubyMine 4 test runs

### DIFF
--- a/lib/minitest/test_runner.rb
+++ b/lib/minitest/test_runner.rb
@@ -8,7 +8,7 @@ module MiniTest
   # 
   # @see https://github.com/seattlerb/minitest MiniTest
   class TestRunner
-    attr_reader :suite, :test, :assertions, :result, :exception
+    attr_reader :suite, :test, :assertions, :result, :exception, :options
     
     def initialize(suite, test)
       @suite = suite


### PR DESCRIPTION
Added :options attribute to MiniTest::TestRunner so RubyMine test runs does not fail.  Without it RubyMine 4 was failing.

NoMethodError: undefined method `options' for #<MiniTest::TestRunner:0x007f8845726d28>
/Users/geoffcorey/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/test/unit/testcase.rb:16:in`run'
