### PR TITLE
add :detailed_skip options to progress reporter

### DIFF
--- a/lib/minitest/reporter.rb
+++ b/lib/minitest/reporter.rb
@@ -1,7 +1,7 @@
 module MiniTest
   module Reporter
     def runner
-      MiniTest::Unit.runner
+      (@options && @options[:runner]) || MiniTest::Unit.runner
     end
     
     def output

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -16,8 +16,16 @@ module MiniTest
 
       INFO_PADDING = 2
 
-      def initialize(backtrace_filter = MiniTest::BacktraceFilter.default_filter)
-        @backtrace_filter = backtrace_filter
+      def initialize(options={})
+        unless options.is_a?(Hash)
+          warn "Please use :backtrace_filter => filter instead of passing filter directly"
+          options = {:backtrace_filter => options}
+        end
+
+        @options = {
+          :backtrace_filter => MiniTest::BacktraceFilter.default_filter,
+          :detailed_skip => true
+        }.merge(options)
       end
 
       def before_suites(suites, type)
@@ -44,10 +52,12 @@ module MiniTest
 
       def skip(suite, test, test_runner)
         @color = YELLOW unless @color == RED
-        print(yellow { 'SKIP' })
-        print_test_with_time(suite, test)
-        puts
-        puts
+        if @options[:detailed_skip]
+          print(yellow { 'SKIP' })
+          print_test_with_time(suite, test)
+          puts
+          puts
+        end
         increment
       end
 
@@ -94,7 +104,7 @@ module MiniTest
       def print_info(e)
         e.message.each_line { |line| puts pad(line) }
 
-        trace = @backtrace_filter.filter(e.backtrace)
+        trace = @options[:backtrace_filter].filter(e.backtrace)
         trace.each { |line| puts pad(line) }
       end
 

--- a/test/minitest/reporters/progress_reporter_test.rb
+++ b/test/minitest/reporters/progress_reporter_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+module MiniTestReportersTest
+  class ProgressReporterTest < TestCase
+    # negated copy of assert_includes
+    def assert_not_includes collection, obj, msg = nil
+      msg = message(msg) { "Expected #{mu_pp(collection)} to not include #{mu_pp(obj)}" }
+      assert_respond_to collection, :include?
+      assert !collection.include?(obj), msg
+    end
+
+    def reporter(*args)
+      Minitest::Reporters::ProgressReporter.new(*args)
+    end
+
+    def output(reporter)
+      reporter.output.rewind
+      reporter.output.read.gsub(/\e\[(\d+m|K)/,'') # decolorize
+    end
+
+    def setup
+      out = StringIO.new
+      @runner = stub(:output => out, :test_count => 1, :test_start_time => Time.now)
+    end
+
+    test "displays skip by default" do
+      reporter = reporter(:runner => @runner)
+      reporter.before_suites(:foo, :bar)
+      reporter.skip(:foo, :bar, :baz)
+      assert_includes output(reporter), "SKIP foo#bar (0.00s)"
+    end
+
+    test "hides skip when :hide_skip is given" do
+      reporter = reporter(:runner => @runner, :detailed_skip => nil)
+      reporter.before_suites(:foo, :bar)
+      reporter.skip(:foo, :bar, :baz)
+      assert_not_includes output(reporter), "SKIP foo#bar (0.00s)"
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 require 'minitest/autorun'
 require 'mocha'
+require 'stringio'
 require 'test_declarative'
 require 'minitest/reporters'
 


### PR DESCRIPTION
I'm trying to use reporters for a project that has lots of skips (that cannot be solved atm),
so silencing the output of skip turns a giant dump of skip messages into a nice and clean progressbar :)

This also introduces tests for runners, which might look a little clumsy but that's the best I could come up with, improvements welcome!
