### PR TITLE
remove the need for boilerplate code

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ Death to haphazard monkey-patching! Extend MiniTest through simple hooks.
 In your `test_helper.rb` file, add the following lines:
 
     require 'minitest/reporters'
-    MiniTest::Unit.runner = MiniTest::SuiteRunner.new
-    MiniTest::Unit.runner.reporters << MiniTest::Reporters::ProgressReporter.new
+    MiniTest::Runners.choose_runner!
 
-Now, just run your tests; the reporter you specified will be used and make your
-output look absolutely gorgeous! If you feel the need to write your own
-reporter, just `include MiniTest::Reporter` and override the methods you'd like.
+The correct formatter will be chosen for Textmate/Rubymine/console.
+If you feel the need to write your own reporter, just `include MiniTest::Reporter` and override the methods you'd like.
 Take a look at the provided reporters for examples.
+
+Don't like progressbar ?
+
+    MiniTest::Runners.choose_runner! :console => MiniTest::Reporters::SpecReporter.new
+
 
 The following reporters are provided:
 
@@ -28,29 +31,8 @@ The following reporters are provided:
     MiniTest::Reporters::RubyMineReporter # => Reporter designed for RubyMine IDE and TeamCity CI server; see below
     MiniTest::Reporters::GuardReporter # => Integrates with guard-minitest to provide on-screen notifications
 
-I really like `ProgressReporter` for my everyday terminal usage, but I like
-using `RubyMateReporter` when I'm executing test suites from TextMate. My usual
-set up looks like this:
-
-    require 'minitest/reporters'
-    MiniTest::Unit.runner = MiniTest::SuiteRunner.new
-    if ENV['TM_PID']
-      MiniTest::Unit.runner.reporters << MiniTest::Reporters::RubyMateReporter.new
-    else
-      MiniTest::Unit.runner.reporters << MiniTest::Reporters::ProgressReporter.new
-    end
-
-If you prefer integration with RubyMine test runner or TeamCity CI server you'll need:
-
-    if ENV["RM_INFO"] || ENV["TEAMCITY_VERSION"]
-      MiniTest::Unit.runner.reporters << MiniTest::Reporters::RubyMineReporter.new
-    else
-      ...
-    end
-
 ## TODO ##
 
-* Make the boilerplate code look prettier. Something like a one-line require for the general use-case would be nice.
 * Add some example images of the reporters.
 
 ## Note on Patches/Pull Requests ##

--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -16,5 +16,21 @@ module MiniTest
     autoload :RubyMineReporter, "minitest/reporters/rubymine_reporter"
     autoload :GuardReporter, "minitest/reporters/guard_reporter"
     autoload :JUnitReporter, "minitest/reporters/junit_reporter"
+
+    def self.choose_runner!
+      MiniTest::Unit.runner = MiniTest::SuiteRunner.new
+      MiniTest::Unit.runner.reporters << reporter
+    end
+
+    def self.reporter(options={})
+      env = options[:env] || ENV
+      if env['TM_PID']
+        RubyMateReporter.new
+      elsif env['RM_INFO'] || env['TEAMCITY_VERSION']
+        RubyMineReporter.new
+      else
+        options[:console] || ProgressReporter.new
+      end
+    end
   end
 end

--- a/test/minitest/reporters_test.rb
+++ b/test/minitest/reporters_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+module MiniTestReportersTest
+  class ReportersTest < TestCase
+    test ".reporter sets up progressbar by default" do
+      reporter = Minitest::Reporters.reporter :env => {}
+      assert_equal MiniTest::Reporters::ProgressReporter, reporter.class
+    end
+
+    test ".reporter uses Rubymine when necessary" do
+      MiniTest::Unit.runner.output.stubs(:puts) # Rubymine reporter complains when rubymine libs are not available
+
+      reporter = Minitest::Reporters.reporter :env => {"RM_INFO" => "x"}
+      assert_equal MiniTest::Reporters::RubyMineReporter, reporter.class
+
+      reporter = Minitest::Reporters.reporter :env => {"TEAMCITY_VERSION" => "x"}
+      assert_equal MiniTest::Reporters::RubyMineReporter, reporter.class
+    end
+
+    test ".reporter uses Textmate when necessary" do
+      reporter = Minitest::Reporters.reporter :env => {"TM_PID" => "x"}
+      assert_equal MiniTest::Reporters::RubyMateReporter, reporter.class
+    end
+
+    test ".reporter chooses passed :console reporter with empty env" do
+      reporter = Minitest::Reporters.reporter :env => {}, :console => MiniTest::Reporters::SpecReporter.new
+      assert_equal MiniTest::Reporters::SpecReporter, reporter.class
+    end
+
+    test ".reporter does not choose passed :console reporter with matching env" do
+      reporter = Minitest::Reporters.reporter :env => {"TM_PID" => "x"}, :console => MiniTest::Reporters::SpecReporter.new
+      assert_equal MiniTest::Reporters::RubyMateReporter, reporter.class
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,21 +18,15 @@ module MiniTestReportersTest
   end
 end
 
-MiniTest::Unit.runner = MiniTest::SuiteRunner.new
-
 # Testing the built-in reporters using automated unit testing would be extremely
 # brittle. Consequently, there are no unit tests for them. Instead, uncomment
 # the reporter that you'd like to test and run the full test suite. Make sure to
 # try them with skipped, failing, and error tests as well!
-#
-# Personally, I like the progress reporter. Make sure you don't change that line
-# when you commit.
-if ENV["TM_PID"]
-  MiniTest::Unit.runner.reporters << MiniTest::Reporters::RubyMateReporter.new
-elsif ENV["RM_INFO"]
-  MiniTest::Unit.runner.reporters << MiniTest::Reporters::RubyMineReporter.new
-else
-  # MiniTest::Unit.runner.reporters << MiniTest::Reporters::DefaultReporter.new
-  # MiniTest::Unit.runner.reporters << MiniTest::Reporters::SpecReporter.new
-  MiniTest::Unit.runner.reporters << MiniTest::Reporters::ProgressReporter.new
-end
+
+MiniTest::Reporters.choose_runner!
+
+# MiniTest::Unit.runner.reporters.replace [MiniTest::Reporters::RubyMateReporter.new]
+# MiniTest::Unit.runner.reporters.replace [MiniTest::Reporters::RubyMineReporter.new]
+# MiniTest::Unit.runner.reporters.replace [MiniTest::Reporters::DefaultReporter.new]
+# MiniTest::Unit.runner.reporters.replace [MiniTest::Reporters::SpecReporter.new]
+# MiniTest::Unit.runner.reporters.replace [MiniTest::Reporters::ProgressReporter.new]


### PR DESCRIPTION
``` Ruby
require 'minitest/reporters'
MiniTest::Runners.choose_runner!
```
