### PR TITLE
only load as much ansi as we need

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -1,4 +1,4 @@
-require 'ansi'
+require 'ansi/code'
 
 module MiniTest
   module Reporters

--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -1,4 +1,4 @@
-require 'ansi'
+require 'ansi/code'
 require 'builder'
 require 'fileutils'
 module MiniTest

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -1,4 +1,4 @@
-require 'ansi'
+require 'ansi/code'
 require 'powerbar'
 
 module MiniTest

--- a/lib/minitest/reporters/ruby_mate_reporter.rb
+++ b/lib/minitest/reporters/ruby_mate_reporter.rb
@@ -1,4 +1,4 @@
-require 'ansi'
+require 'ansi/code'
 
 module MiniTest
   module Reporters

--- a/lib/minitest/reporters/rubymine_reporter.rb
+++ b/lib/minitest/reporters/rubymine_reporter.rb
@@ -1,7 +1,7 @@
 # Test results reporter for RubyMine IDE (http://www.jetbrains.com/ruby/) and
 # TeamCity(http://www.jetbrains.com/teamcity/) Continuous Integration Server
 
-require "ansi"
+require 'ansi/code'
 begin
   require 'teamcity/runner_common'
   require 'teamcity/utils/service_message_factory'

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -1,4 +1,4 @@
-require 'ansi'
+require 'ansi/code'
 
 module MiniTest
   module Reporters


### PR DESCRIPTION
- pretty big -> slow
- contains kernal patches (global ansi method)
- contains global variables

so let's not load all that crap :)
