### PR TITLE
Let's use filter_backtrace().join(n)  to format backtrace for RM

### DIFF
--- a/lib/minitest/reporters/rubymine_reporter.rb
+++ b/lib/minitest/reporters/rubymine_reporter.rb
@@ -139,7 +139,7 @@ else
             if block_given?
               exception = test_runner.exception
               msg = exception.nil? ? "" : "#{exception.class.name}: #{exception.message}"
-              backtrace = exception.nil? ? "" : format_backtrace(exception.backtrace)
+              backtrace = exception.nil? ? "" : filter_backtrace(exception.backtrace).join("\n")
 
               yield(msg, backtrace)
             end


### PR DESCRIPTION
form_backtrace() has been removed in the resent version of Rake::TeamCity::RunnerCommon, and it looks like a good idea to use filter_backtrace().join("\n"). 
