### PR TITLE
Update lib/minitest/reporters/default_reporter.rb

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -158,7 +158,7 @@ module MiniTest
       end
 
       def after_test(result)
-        time = Time.now - runner.test_start_time
+        time = Time.now - (runner.test_start_time || Time.now)
         @test_times << [@test_name, time]
 
         print '%.2f s = ' % time if verbose?


### PR DESCRIPTION
I had a problem with the following error when trying to run a test file individually from within RubyMine:

/Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/activesupport-3.2.9/lib/active_support/core_ext/time/calculations.rb:326:in `-': can't convert nil into an exact number (TypeError)

```
from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/activesupport-3.2.9/lib/active_support/core_ext/time/calculations.rb:326:in `minus_with_duration'




from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/activesupport-3.2.9/lib/active_support/core_ext/time/calculations.rb:337:in `minus_with_coercion'
from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-reporters-0.13.1/lib/minitest/reporters/default_reporter.rb:139:in `after_test'
```

F   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-reporters-0.13.1/lib/minitest/reporters/default_reporter.rb:41:in `pass'
a   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-reporters-0.13.1/lib/minitest/reporter_runner.rb:77:in`public_send'
b   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-reporters-0.13.1/lib/minitest/reporter_runner.rb:77:in `block in trigger_callback'
u   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-reporters-0.13.1/lib/minitest/reporter_runner.rb:76:in`each'
l   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-reporters-0.13.1/lib/minitest/reporter_runner.rb:76:in `trigger_callback'
o   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-reporters-0.13.1/lib/minitest/reporter_runner.rb:61:in`record'
u   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:887:in `block in _run_suite'
s   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:876:in`map'
   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:876:in `_run_suite'
t   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-reporters-0.13.1/lib/minitest/reporter_runner.rb:30:in`_run_suite'
e   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:863:in `block in _run_suites'
s   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:863:in`map'
t   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:863:in `_run_suites'
s   from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-reporters-0.13.1/lib/minitest/reporter_runner.rb:22:in`_run_suites'
 in 0.165924s, 36.1611 tests/s, 6.0269 assertions/s.
    from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:836:in `_run_anything'

```
from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:1025:in `run_tests'
```

6 tests, 1 assertions, 0 failures, 0 errors, 0 skips    from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:1012:in `block in _run'
    from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:1011:in`each'
    from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:1011:in `_run'
    from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:1000:in`run'
    from /Users/mcowden/.rvm/gems/ruby-1.9.2-p290@ruby1.9/gems/minitest-4.1.0/lib/minitest/unit.rb:758:in `block in autorun'
Coverage report generated for Unit Tests to /Users/mcowden/Development/bna/bas/test/models/coverage. 0 / 0 LOC (0.0%) covered.
