### PR TITLE
Add handling for when runner.test_start_time is nil

### DIFF
--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -105,7 +105,7 @@ module MiniTest
       end
 
       def print_test_with_time(suite, test)
-        total_time = Time.now - runner.test_start_time
+        total_time = Time.now - (runner.test_start_time || Time.now)
         print(" %s#%s (%.2fs)%s" % [suite, test, total_time, clr])
       end
 


### PR DESCRIPTION
When running in an older version of minitest, our selenium
integration (based on MiniTest::Spec) does not call #before_test
before calling #print_test_with_time for the first time.
Defaulting test_start_time to Time.now does not seem to effect
the rest of the test run, and times are reported correctly.
