### PR TITLE
Make JUnitReporter compatible with Ruby < 1.9.3.

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -33,7 +33,7 @@ module MiniTest
               end
             end
           end
-          IO.write(filename_for(suite), xml.target!)
+          File.open(filename_for(suite), "w") { |file| file << xml.target! }
         end
       end
 


### PR DESCRIPTION
IO.write is a new method as of Ruby 1.9.3, so use File.open and << instead.

There was no direct unit test of this behavior, but the gallery test was failing instead of writing test reports.
