### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following reporters are provided:
     MiniTest::Reporters::SpecReporter     # => Turn-like output that reads like a spec
     MiniTest::Reporters::ProgressReporter # => Fuubar-like output with a progress bar
     MiniTest::Reporters::RubyMateReporter # => Simple reporter designed for RubyMate
-    MiniTest::Reporters::RubyMineReporter # => Reporter designed for RubyMine IDE and TeamCity CI server; see below
+    MiniTest::Reporters::RubyMineReporter # => Reporter designed for RubyMine IDE and TeamCity CI server
     MiniTest::Reporters::GuardReporter    # => Integrates with guard-minitest to provide on-screen notifications
     MiniTest::Reporters::JUnitReporter    # => JUnit test reporter designed for JetBrains TeamCity
 


### PR DESCRIPTION
Hi, I noticed there's a JUnit reporter in lib/minitest/reporters, but it wasn't mentioned in the README.

There was also a note that said 'see below' for the RubyMineReporter line but I didn't see anything below that was relevant to that reporter.

Thanks, I :heart: this gem!!! 
