### PR TITLE
Explicitly load the forwardable library

### DIFF
--- a/lib/minitest/reporter_runner.rb
+++ b/lib/minitest/reporter_runner.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module MiniTest
   # Runner for MiniTest that supports reporters.
   #


### PR DESCRIPTION
The `forwardable` lib is not loaded by default. I was getting an "uninitialized constant" error because I did not have it loaded when I tried to load `minitest-reporters`.
