### PR TITLE
Require parallel-each to make it work

### DIFF
--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -1,4 +1,5 @@
 require "minitest/unit"
+require 'minitest/parallel_each'
 
 module MiniTest
   require "minitest/relative_position"


### PR DESCRIPTION
Seems you forget to require parallel_each. I'm getting exception while trying to run tests:

```
`use_parallel_length_method!': uninitialized constant MiniTest::Reporters::ParallelEach (NameError)
```
