### PR TITLE
Reporters count correctly when :teardown fails/errors.

### DIFF
--- a/lib/minitest/reporter.rb
+++ b/lib/minitest/reporter.rb
@@ -29,6 +29,7 @@ module MiniTest
     def before_suite(suite); end
     def after_suite(suite); end
     def before_test(suite, test); end
+    def after_test(suite, test); end
     def pass(suite, test, test_runner); end
     def skip(suite, test, test_runner); end
     def failure(suite, test, test_runner); end

--- a/lib/minitest/reporter_runner.rb
+++ b/lib/minitest/reporter_runner.rb
@@ -64,6 +64,7 @@ module MiniTest
       runners.each do |runner|
         trigger_callback(runner.result, suite, test.to_sym, runner)
       end
+      trigger_callback(:after_test, suite, test.to_sym)
     end
 
     # Stub out the three IO methods used by the built-in reporter.

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -40,11 +40,11 @@ module MiniTest
       end
 
       def pass(suite, test, test_runner)
-        after_test(green('.'))
+        test_result(green('.'))
       end
 
       def skip(suite, test, test_runner)
-        after_test(yellow('S'))
+        test_result(yellow('S'))
       end
 
       def failure(suite, test, test_runner)
@@ -56,7 +56,7 @@ module MiniTest
           puts
           print_info(test_runner.exception)
         else
-          after_test(red('F'))
+          test_result(red('F'))
         end
       end
 
@@ -69,7 +69,7 @@ module MiniTest
           puts
           print_info(test_runner.exception)
         else
-          after_test(red('E'))
+          test_result(red('E'))
         end
       end
 
@@ -157,7 +157,7 @@ module MiniTest
         end
       end
 
-      def after_test(result)
+      def test_result(result)
         time = Time.now - (runner.test_start_time || Time.now)
         @test_times << [@test_name, time]
 

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -43,7 +43,7 @@ module MiniTest
         }, true)
       end
 
-      def pass(suite, test, test_runner)
+      def after_test(suite, test)
         increment
       end
 
@@ -57,7 +57,6 @@ module MiniTest
         end
 
         self.color = YELLOW unless color == RED
-        increment
       end
 
       def failure(suite, test, test_runner)
@@ -69,7 +68,6 @@ module MiniTest
         puts
 
         self.color = RED
-        increment
       end
 
       def error(suite, test, test_runner)
@@ -81,7 +79,6 @@ module MiniTest
         puts
 
         self.color = RED
-        increment
       end
 
       def after_suites(suites, type)

--- a/test/unit/minitest/reporter_test.rb
+++ b/test/unit/minitest/reporter_test.rb
@@ -12,7 +12,7 @@ module MiniTestReportersTest
 
     def test_callbacks
       [
-        :before_suites, :after_suite, :before_suite, :after_suite, :before_test,
+        :before_suites, :after_suite, :before_suite, :after_suite, :before_test, :after_test,
         :pass, :skip, :failure, :error
       ].each { |method| assert_respond_to @reporter, method }
     end


### PR DESCRIPTION
This is one more little tweak to the work you did on #49, which otherwise works very well.  Thank you.

When there is a failure or exception in a :teardown, ProgressReporter
was counting the test twice, resulting in a > 100% completion
percentage.

RubyMineReporter was counting the additional failure or error as a
separate test and logging a warning to the console.
- Add an :after_test callback to the reporters.
- Rename DefaultReporter's now-conflicting :after_test to
  :test_result.
- Both reporters report test completion status in after_test instead
  of in the various pass/fail/etc. methods.
