### PR TITLE
Print run options when running test suites. 

### DIFF
--- a/lib/minitest/reporter_runner.rb
+++ b/lib/minitest/reporter_runner.rb
@@ -25,6 +25,8 @@ module MiniTest
     end
 
     def _run_suites(suites, type)
+      MiniTest::Unit.runner.output.puts "# Run options: #{@help}"
+
       @suites_start_time = Time.now
       count_tests!(suites, type)
       trigger_callback(:before_suites, suites, type)


### PR DESCRIPTION
This would include information such as --seed which is useful for debugging tests.
