### PR TITLE
Improve auto-detection of color-capable terminals

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -21,8 +21,7 @@ module MiniTest
         @suite_times = []
         @color = options.fetch(:color) do
           output.tty? && (
-            ENV["TERM"] == "screen" ||
-            ENV["TERM"] =~ /term(?:-(?:256)?color)?\z/ ||
+            ENV["TERM"] =~ /^screen|color/ ||
             ENV["EMACS"] == "t"
           )
         end


### PR DESCRIPTION
Terminals such as 'screen-256color', 'rxvt-unicode-256color' etc.
were not automatically detected as color-capable.

https://github.com/CapnKernul/minitest-reporters/pull/60#issuecomment-15015863
