### PR TITLE
Escape double quotes in test name in JUnit reporter (prevent XML breakage)...

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -33,7 +33,8 @@ module MiniTest
                         :errors => suite_result[:error_count], :tests => suite_result[:test_count],
                         :assertions => suite_result[:assertion_count], :time => suite_result[:time]) do
             tests.each do |test, test_runner|
-              xml.testcase(:name => test_runner.test, :classname => suite, :assertions => test_runner.assertions,
+              escaped_test_name = test_runner.test.to_s.gsub('"', '&quot;')
+              xml.testcase(:name => escaped_test_name, :classname => suite, :assertions => test_runner.assertions,
                            :time => test_runner.time) do
                 xml << xml_message_for(test_runner) if test_runner.result != :pass
               end

--- a/lib/minitest/reporters/version.rb
+++ b/lib/minitest/reporters/version.rb
@@ -1,5 +1,5 @@
 module MiniTest
   module Reporters
-    VERSION = "0.14.12"
+    VERSION = "0.14.13"
   end
 end


### PR DESCRIPTION
- some test frameworks allow quotes (e.g. Shoulda)
