### PR TITLE
Add a newline after all suites run in the default reporter.

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -123,6 +123,7 @@ module MiniTest
 
         puts
         print colored_for(suite_result, result_line)
+        puts
       end
 
       private


### PR DESCRIPTION
Hi,

Really minor, but I noticed that there wasn't a newline after the last bit of output with the default reporter. It bothered me enough that I fixed it. This didn't seem worth a test, so I didn't add one. All existing tests passed.

Thanks,
Steve
