### PR TITLE
Fix bug in backtrace filter when backtrace is nil

### DIFF
--- a/lib/minitest/extensible_backtrace_filter.rb
+++ b/lib/minitest/extensible_backtrace_filter.rb
@@ -51,6 +51,7 @@ module MiniTest
     # @note This logic is based off of MiniTest's #filter_backtrace.
     def filter(backtrace)
       result = []
+      return result unless backtrace
 
       backtrace.each do |line|
         break if filters?(line)

--- a/test/unit/minitest/extensible_backtrace_filter_test.rb
+++ b/test/unit/minitest/extensible_backtrace_filter_test.rb
@@ -34,5 +34,9 @@ module MiniTestReportersTest
       assert @default_filter.filters?("lib/minitest/reporters")
       refute @default_filter.filters?("lib/my_gem")
     end
+
+    def test_nil_backtrace
+      assert_equal [], @filter.filter(nil)
+    end
   end
 end


### PR DESCRIPTION
An exception without a backtrace happens in our test suite when using #assert_raise with an actual exception instance (vs the class + message signature). This is the easiest fix, and I don't see any downside to having the filter handle that case.
