### PR TITLE
SpecReporter: show fail/err count in green if zero

### DIFF
--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -22,7 +22,8 @@ module Minitest
         super
         puts('Finished in %.5fs' % total_time)
         print('%d tests, %d assertions, ' % [count, assertions])
-        print(red { '%d failures, %d errors, ' } % [failures, errors])
+        color = failures.zero? && errors.zero? ? :green : :red
+        print(send(color) { '%d failures, %d errors, ' } % [failures, errors])
         print(yellow { '%d skips' } % skips)
         puts
       end


### PR DESCRIPTION
Spec reporter shows the "x failures, x errors" text in red. But if there are no failures or errors, the red is misleading. I see the red and want to look for an error.

This patch changes that text to green if there are no failures and no errors.
