### PR TITLE
Fix output of Minitest::UnexpectedErrors.

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -160,8 +160,7 @@ module Minitest
             "Skipped:\n#{test.class}##{test.name} [#{location(e)}]:\n#{e.message}"
           end
         elsif test.error?
-          bt = filter_backtrace(e.backtrace).join "\n    "
-          "Error:\n#{test.class}##{test.name}:\n#{e.class}: #{e.message}\n    #{bt}"
+          "Error:\n#{test.class}##{test.name}:\n#{e.message}"
         else
           "Failure:\n#{test.class}##{test.name}:\n#{e.class}: #{e.message}"
         end

--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -83,8 +83,7 @@ module Minitest
         elsif test.failure
           "Failure:\n#{name}(#{suite}) [#{location(e)}]:\n#{e.message}\n"
         elsif test.error?
-          bt = filter_backtrace(test.exception.backtrace).join "\n    "
-          "Error:\n#{name}(#{suite}):\n#{e.class}: #{e.message}\n    #{bt}\n"
+          "Error:\n#{name}(#{suite}):\n#{e.message}"
         end
       end
 


### PR DESCRIPTION
No need to filter the backtrace, print the class or message as these are already done by `UnexpectedError` (which wraps all errors as-of Minitest 5).

Without this change:

```
Error:
TestSomething#test_something:
Minitest::UnexpectedError: RuntimeError: 
    /Users/mike/something/something_test.rb:24:in `test_something'
    /Users/mike/something/something_test.rb:24:in `test_something'
```

With this change:

```
Error:
TestSomething#test_something:
RuntimeError: 
    /Users/mike/something/something_test.rb:24:in `test_something'
```
