### PR TITLE
Keep cursor shown in ProgressReporter so it isn't hidden in debugger.

### DIFF
--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -24,7 +24,7 @@ module Minitest
         @progress.settings.tty.finite.output = lambda { |s| print(s) }
         @progress.settings.tty.finite.template.barchar = "="
         @progress.settings.tty.finite.template.padchar = " "
-        @progress.settings.tty.finite.template.pre = "\e[1000D\e[?25l#{GREEN}"
+        @progress.settings.tty.finite.template.pre = "\e[1000D#{GREEN}"
         @progress.settings.tty.finite.template.post = CLEAR
       end
 
@@ -95,7 +95,7 @@ module Minitest
 
       def color=(color)
         @color = color
-        @progress.scope.template.pre = "\e[1000D\e[?25l#{@color}"
+        @progress.scope.template.pre = "\e[1000D#{@color}"
       end
     end
   end


### PR DESCRIPTION
@os97673 for review
cc @csaunders

Fixes #76
## Problem

When using the ProgressReporter, the cursor will be hidden when in the debugger.

This can be reproduced by starting the debugger in a test as follows

```
require 'minitest/autorun'
require "minitest/reporters"
Minitest::Reporters.use! Minitest::Reporters::ProgressReporter.new

require 'byebug'

class DebugTest < Minitest::Test
  def test_1
  end

  def test_debugger
    debugger
  end
end
```

The first test was added to make sure the progress bar is printed before the debugger line, since that was what was hiding the debugger.
## Solution

Avoid hiding the cursor.

The cursor will just be visible at the end of the line with the progress bar.
