### PR TITLE
Compatibility with newer versions of minitest.  To avoid scary message that wrong file is being required.

### DIFF
--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -1,4 +1,8 @@
-require "minitest/autorun"
+begin
+  require "minitest/autorun"
+rescue
+  require "minitest/unit"
+end
 
 module Minitest
   require "minitest/relative_position"


### PR DESCRIPTION
require 'minitest/unit' generates a scary message saying that minitest/autorun should be required instead.
