### PR TITLE
Fix typo in section Usage/color output

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Options can be passed to these reporters at construction-time, e.g. to force
 color output from `DefaultReporter`:
 
 ```ruby
-Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new(:color => true)]
+Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(:color => true)]
 ```
 
 ## Screenshots ##


### PR DESCRIPTION
`SpecReporter` does not accept the color option but `DefaultReporter` does.
Fixed doc accordingly.
