### PR TITLE
kern/minitest-reporters#103: Switching from PowerBar to ruby-progressbar

### DIFF
--- a/minitest-reporters.gemspec
+++ b/minitest-reporters.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'minitest', '>= 5.0'
   s.add_dependency 'ansi'
-  s.add_dependency 'powerbar'
+  s.add_dependency 'ruby-progressbar'
   s.add_dependency 'builder'
 
   s.add_development_dependency 'maruku'


### PR DESCRIPTION
PowerBar seems to be a bit defunct (last updated a year ago, years-old
issues sitting open). But, most importantly, the `ProgressReporter`
makes my tests run 50% slower than any other reporter. That doesn’t
seem right—whatever is being done to generate the progress bar couldn’t
possibly be complicated enough to increase the test run time by 50%.

Since PowerBar is defunct I figured the easiest way is to just switch
to something actively developed, like ruby-progressbar, and that did
the trick. Test run times with the `ProgressReporter` now average the
same as the other reporters.

The output will almost be completely identical. The one change I made
is that now only the progress bar will be colored. Previously the
entire line would be green, and then change to yellow or red if there
was a skip or failure. Now only the progress bar itself will change
color, which makes the output visually easier to read.
