### PR TITLE
Do not require autorun

### DIFF
--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -1,8 +1,4 @@
-begin
-  require "minitest/autorun"
-rescue
-  require "minitest/unit"
-end
+require 'minitest'
 
 module Minitest
   require "minitest/relative_position"


### PR DESCRIPTION
Requiring autorun makes Minitest to run the tests in an `at_exit` block, which
may or may not be what the user wants. This change makes the gem less
opinionated and lets the developer using the gem decide when and how to run the
tests.

Related https://github.com/kern/minitest-reporters/pull/100
