### PR TITLE
Show location of test failures

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -162,7 +162,7 @@ module Minitest
         elsif test.error?
           "Error:\n#{test.class}##{test.name}:\n#{e.message}"
         else
-          "Failure:\n#{test.class}##{test.name}:\n#{e.class}: #{e.message}"
+          "Failure:\n#{test.class}##{test.name} [#{test.failure.location}]\n#{e.class}: #{e.message}"
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,9 @@ end
 # brittle. Consequently, there are no unit tests for them.  If you'd like to run
 # all the reporters sequentially on a fake test suite, run `rake gallery`.
 
-if ENV["REPORTER"]
+if ENV["REPORTER"] == "Pride"
+  require "minitest/pride"
+elsif ENV["REPORTER"]
   reporter_klass = Minitest::Reporters.const_get(ENV["REPORTER"])
   Minitest::Reporters.use!(reporter_klass.new)
 else


### PR DESCRIPTION
While exception messages show a the file name/line number where the exception was thrown, actual test failures (e.g. `refute true`) were not displaying the location of the exception.

To expose the problem, I ran the bad test gallery with stock minitest pride output. The `__FILE__` and `__LINE__` where the failed assert occurred were showing up. However, when I switched to `Minitest::Reporters::DefaultReporter`, the failure location was gone.

I also added the ability to easily run the galleries with minitest pride output as a way of testing the formatting of `DefaultReporter` against stock minitest in the future.
