### PR TITLE
Provide hooks for outputting successful, failed, skipped tests

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -38,17 +38,29 @@ module Minitest
         print "#{"%.2f" % test.time} = " if options[:verbose]
 
         print(if test.passed?
-          green('.')
+          record_pass(test)
         elsif test.skipped?
-          yellow('S')
+          record_skip(test)
         elsif test.failure
-          red('F')
+          record_failure(test)
         end)
 
         if @fast_fail && (test.skipped? || test.failure)
           puts
           print_failure(test)
         end
+      end
+
+      def record_pass(test)
+        green('.')
+      end
+
+      def record_skip(test)
+        yellow('S')
+      end
+
+      def record_failure(test)
+        red('F')
       end
 
       def report


### PR DESCRIPTION
I wanted to be able to modify the output delivered for each type of test result, but the way that the `#record` method was written made it difficult to do so.  Splitting these off into separate methods made customization easier.

This is a minor change.  The functioning of DefaultReporter should be identical.
