### PR TITLE
Fix NoMethodError when using Progress Reporter with empty test classes

### DIFF
--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -73,10 +73,8 @@ module Minitest
       private
 
       def show
-        return if count == 0
-
         @progress.total = total_count
-        @progress.increment
+        @progress.increment unless count == 0
       end
 
       def print_test_with_time(test)


### PR DESCRIPTION
This is a minor change that fixes Issue #112.  Calling finish on the progress bar without setting the total causes the exception to the raised.
