### PR TITLE
Fix handling of totals in ProgressReporter

### DIFF
--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -35,6 +35,7 @@ module Minitest
         puts 'Started'
         puts
         @progress.start
+        @progress.total = total_count
         show
       end
 
@@ -73,10 +74,7 @@ module Minitest
       private
 
       def show
-        return if count == 0
-
-        @progress.total = total_count
-        @progress.increment
+        @progress.increment unless count == 0
       end
 
       def print_test_with_time(test)


### PR DESCRIPTION
Here are my changes per pull request #113 and issue #112.  Instead of repeatedly setting the total every time a test is run, we can set it once when we start the progress bar, presumably because the number of tests should not be changing during a test run.
