### PR TITLE
Fix for ActiveSupport 3.2.18

### DIFF
--- a/lib/minitest/old_activesupport_fix.rb
+++ b/lib/minitest/old_activesupport_fix.rb
@@ -3,7 +3,7 @@ require "active_support/testing/setup_and_teardown"
 module ActiveSupport
   module Testing
     module SetupAndTeardown
-      module ForMinitest
+      module ForMiniTest
         remove_method :run
 
         def before_setup


### PR DESCRIPTION
ActiveSupport 3.2.18 has renamed the `ActiveSupport::Testing::SetupAndTeardown::ForMinitest` module to: `ActiveSupport::Testing::SetupAndTeardown::ForMiniTest`. This fixes the error in: kern/minitest-reporters#91, however probably will break ActiveSupport < 3.2.18.