### PR TITLE
Always output run options, which include the seed used

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -13,6 +13,11 @@ module Minitest
         self.options = defaults.merge(options)
       end
 
+      def start
+        super
+        puts "Run options: #{options[:args]}"
+      end
+
       # called by our own before hooks
       def before_test(test)
         last_test = tests.last


### PR DESCRIPTION
This is important because of Minitest's random ordering-- if there are
bugs that occur in some orderings, being able to run with the same seed
to reproduce the same ordering is essential.

This was added to minitest-reporters once before, in df651b0, but looks
like it didn't survive the 1.0 refactoring :) Discussion when that was
added: https://github.com/kern/minitest-reporters/pull/55/files
