### PR TITLE
Always output run options for stdout reporters

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -25,7 +25,7 @@ module Minitest
       def start
         super
         puts
-        puts "# Running tests:"
+        puts("# Running tests with run options %s:" % options[:args])
         puts
       end
 

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -32,7 +32,7 @@ module Minitest
 
       def start
         super
-        puts 'Started'
+        puts('Started with run options %s' % options[:args])
         puts
         @progress.start
         @progress.total = total_count

--- a/lib/minitest/reporters/ruby_mate_reporter.rb
+++ b/lib/minitest/reporters/ruby_mate_reporter.rb
@@ -10,7 +10,7 @@ module Minitest
 
       def start
         super
-        puts 'Started'
+        puts('Started with run options %s' % options[:args])
         puts
       end
 

--- a/lib/minitest/reporters/rubymine_reporter.rb
+++ b/lib/minitest/reporters/rubymine_reporter.rb
@@ -34,7 +34,7 @@ else
 
         def start
           super
-          puts 'Started'
+          puts('Started with run options %s' % options[:args])
           puts
 
           # Setup test runner's MessageFactory

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -14,7 +14,7 @@ module Minitest
 
       def start
         super
-        puts 'Started'
+        puts('Started with run options %s' % options[:args])
         puts
       end
 


### PR DESCRIPTION
Ok, I think I like this better than putting this in base_reporter as I did in #123, but let me know if you like that one better. I also [tried a more hacky way using `Minitest.after_run`](https://github.com/thinkthroughmath/minitest-reporters/commit/0f5489212313ee6ce7be8cd0a8fa584665890950), but I don't really like that either.

This is important because of Minitest's random ordering-- if there are
bugs that occur in some orderings, being able to run with the same seed
to reproduce the same ordering is essential.

This was added to minitest-reporters once before, in df651b0, but looks
like it didn't survive the 1.0 refactoring :) Discussion when that was
added: https://github.com/kern/minitest-reporters/pull/55/files

Did not add to the junit reporter since its output mostly goes to XML
files, not stdout, and if you use it in conjunction with the other
reporters that typically print to stdout, you will see this twice. If
you use multiple stdout reporters, you're going to get a lot of
duplicate info as well.
