### PR TITLE
Delete needless attribute

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -1,7 +1,6 @@
 module Minitest
   module Reporters
     class BaseReporter < Minitest::StatisticsReporter
-      attr_accessor :total_count
       attr_accessor :tests
 
       def initialize(options={})


### PR DESCRIPTION
It causes `minitest-reporters-1.0.5/lib/minitest/reporters/base_reporter.rb:73: warning: method redefined; discarding old total_count`.
And as long as I grepped, seems that `total_count=` method is not used.
