### PR TITLE
Follow minitest API, and use result_code to label the test result

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -64,16 +64,16 @@ module Minitest
         end
       end
 
-      def record_pass(test)
-        green('.')
+      def record_pass(record)
+        green(record.result_code)
       end
 
-      def record_skip(test)
-        yellow('S')
+      def record_skip(record)
+        yellow(record.result_code)
       end
 
-      def record_failure(test)
-        red('F')
+      def record_failure(record)
+        red(record.result_code)
       end
 
       def report


### PR DESCRIPTION
We have some code that changes the `result_code` depending on a few new Assertion we have.
That works fine on raw minitest, as the minitest default reporter uses `result_code` ( https://github.com/seattlerb/minitest/blob/master/lib/minitest.rb#L454 ), however when adding a minitest-reporters reporter, it stopped showing the right result, as it is not using the method.
