### PR TITLE
Add failure summary report to spec_reporter.

### DIFF
--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -20,6 +20,7 @@ module Minitest
 
       def report
         super
+        print_error_summary
         puts('Finished in %.5fs' % total_time)
         print('%d tests, %d assertions, ' % [count, assertions])
         color = failures.zero? && errors.zero? ? :green : :red
@@ -41,6 +42,23 @@ module Minitest
       end
 
       protected
+
+      BASE_OFFSET = 2
+
+      # Prints an error summary at the end of the test suite, excluding skipped tests.
+      def print_error_summary
+        padding   = errors.size.to_s.length + BASE_OFFSET
+        # `results` contains only Errors and Failures
+        results.reject(&:skipped?).each_with_index do |error, index|
+          lines = error.to_s.split("\n")
+          first_line = lines.shift(2).join(" ")
+          io.puts "\n%#{padding}d) %s" % [index + 1, first_line]
+          lines.each do |line|
+            io.puts (" " * (padding+5)) + line
+          end
+        end
+        io.puts
+      end
 
       def before_suite(suite)
         puts suite


### PR DESCRIPTION
@os97673 

Scrolling through hundreds -- or in our case thousands -- of test results to locate the failure message for one or a handful of tests is rather painful.  This adds an error summary report to the end of the spec reporter, but before the final test summary is printed.  It omits skipped tests.

You can view the resulting output of this PR by running `bundle exec rake gallery`, or:

```
  1) Failure: MinitestReportersTest::BadTest#test_a [minitest-reporters/test/gallery/bad_test.rb:6]:
        Expected: 1
          Actual: 2

  2) Failure: MinitestReportersTest::BadTest#test_b [minitest-reporters/test/gallery/bad_test.rb:14]:
        --- expected
        +++ actual
        @@ -1,2 +1,2 @@
         "ab
        -c"
        +d"

  3) Error: MinitestReportersTest::BadTest#test_boom:
        RuntimeError: A random exception
            minitest-reporters/test/gallery/bad_test.rb:18:in `test_boom'

Finished in 0.01229s
6 tests, 5 assertions, 2 failures, 1 errors, 1 skips
```