### PR TITLE
Allows SpecReporter to only report failures

### DIFF
--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -52,10 +52,6 @@ module Minitest
         end
       end
 
-      def after_test(test)
-
-      end
-
       protected
 
       def before_suite(suite)

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -30,24 +30,40 @@ module Minitest
 
       def record(test)
         super
-        print pad_test(test.name)
-        print_colored_status(test)
-        print(" (%.2fs)" % test.time)
-        puts
-        if !test.skipped? && test.failure
-          print_info(test.failure)
+        if options[:failures_only]
+          if !test.skipped? && test.failure
+            puts test.class.name
+            print pad_test(test.name)
+            print_colored_status(test)
+            print(" (%.2fs)" % test.time)
+            puts
+            print_info(test.failure)
+            puts
+          end
+        else
+          print pad_test(test.name)
+          print_colored_status(test)
+          print(" (%.2fs)" % test.time)
           puts
+          if !test.skipped? && test.failure
+            print_info(test.failure)
+            puts
+          end
         end
+      end
+
+      def after_test(test)
+
       end
 
       protected
 
       def before_suite(suite)
-        puts suite
+        puts suite unless options[:failures_only]
       end
 
       def after_suite(suite)
-        puts
+        puts unless options[:failures_only]
       end
     end
   end


### PR DESCRIPTION
I found the test output a bit noisy in development and it was more useful to just report failures instead of everything.