### PR TITLE
Disabe ANSI color on non-TTY terminals

### DIFF
--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -7,6 +7,7 @@ module Minitest
   module Reporters
     require "minitest/reporters/version"
 
+    autoload :ANSI, "minitest/reporters/ansi"
     autoload :BaseReporter, "minitest/reporters/base_reporter"
     autoload :DefaultReporter, "minitest/reporters/default_reporter"
     autoload :SpecReporter, "minitest/reporters/spec_reporter"

--- a/lib/minitest/reporters/ansi.rb
+++ b/lib/minitest/reporters/ansi.rb
@@ -1,0 +1,24 @@
+module Minitest
+  module Reporters
+    module ANSI
+      module Code
+        if ($stdin.tty?)
+          require 'ansi/code'
+
+          include ::ANSI::Code
+          extend ::ANSI::Code
+        else
+          def black(s = nil)
+            block_given? ? yield : s
+          end
+
+          %w[ red green yellow blue magenta cyan white ].each do |color|
+            alias_method color, :black
+          end
+
+          extend self
+        end
+      end
+    end
+  end
+end

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -1,5 +1,3 @@
-require 'ansi/code'
-
 module Minitest
   module Reporters
     # A reporter identical to the standard Minitest reporter except with more
@@ -8,7 +6,9 @@ module Minitest
     # Based upon Ryan Davis of Seattle.rb's Minitest (MIT License).
     #
     # @see https://github.com/seattlerb/minitest Minitest
+
     class DefaultReporter < BaseReporter
+      include ANSI::Code
       include RelativePosition
 
       def initialize(options = {})

--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -1,4 +1,3 @@
-require 'ansi/code'
 require 'builder'
 require 'fileutils'
 module Minitest

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -1,4 +1,3 @@
-require 'ansi/code'
 require 'ruby-progressbar'
 
 module Minitest

--- a/lib/minitest/reporters/ruby_mate_reporter.rb
+++ b/lib/minitest/reporters/ruby_mate_reporter.rb
@@ -1,5 +1,3 @@
-require 'ansi/code'
-
 module Minitest
   module Reporters
     # Simple reporter designed for RubyMate.

--- a/lib/minitest/reporters/rubymine_reporter.rb
+++ b/lib/minitest/reporters/rubymine_reporter.rb
@@ -1,7 +1,6 @@
 # Test results reporter for RubyMine IDE (http://www.jetbrains.com/ruby/) and
 # TeamCity(http://www.jetbrains.com/teamcity/) Continuous Integration Server
 
-require 'ansi/code'
 begin
   require 'teamcity/runner_common'
   require 'teamcity/utils/service_message_factory'

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -1,5 +1,3 @@
-require 'ansi/code'
-
 module Minitest
   module Reporters
     # Turn-like reporter that reads like a spec.


### PR DESCRIPTION
When running test suites inside an editor, ANSI code often clutters up the output. Differentiating between terminal and editor execution mode is done with `$stdin.tty?`, a method used in one of the reporters but not shared with the others.

There's a stub in here that replaces ANSI::Code with a pass-through equivalent in non-TTY situations.

This requires minimal changes and seems to make the output a lot cleaner in the editor and still preserves the nice color mode on the terminal.

Relates to Issue#134 and may be a possible solution for that problem as well.