### PR TITLE
Fix guard reporter support

### DIFF
--- a/lib/minitest/minitest_reporter_plugin.rb
+++ b/lib/minitest/minitest_reporter_plugin.rb
@@ -5,7 +5,7 @@ module Minitest
         reporter.reporters = Minitest::Reporters.reporters + guard_reporter
         reporter.reporters.each do |reporter|
           reporter.io = options[:io]
-          reporter.add_defaults(options.merge(:total_count => total_count(options)))
+          reporter.add_defaults(options.merge(:total_count => total_count(options))) if reporter.respond_to? :add_defaults
         end
       end
     end


### PR DESCRIPTION
Under minitest 5.5.0 with guard-minitest 2.4.4, there is not add_defaults method on the guard reporter