### PR TITLE
ProgressReporter: No red if no failures or errors

### DIFF
--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -66,7 +66,8 @@ module Minitest
         puts
         puts('Finished in %.5fs' % total_time)
         print('%d tests, %d assertions, ' % [count, assertions])
-        print(red { '%d failures, %d errors, ' } % [failures, errors])
+        color = failures.zero? && errors.zero? ? :green : :red
+        print(send(color) { '%d failures, %d errors, ' } % [failures, errors])
         print(yellow { '%d skips' } % skips)
         puts
       end


### PR DESCRIPTION
Seeing red at the end of a test run is unfortunate when there aren't actually any failures!

Before/after:

![](http://monosnap.com/image/CvO6ORbEFk1Oo4pHmDzV6bK2WZzFp0.png)

This is already how [the SpecReporter behaves](https://github.com/kern/minitest-reporters/blob/6b624d4b75ed07753ca39a87b62a3104a0acfad9/lib/minitest/reporters/spec_reporter.rb#L23-L24).