### PR TITLE
Determines if the terminal supports colors, and if so, enables color output in the reporters.

### DIFF
--- a/lib/minitest/reporters/ansi.rb
+++ b/lib/minitest/reporters/ansi.rb
@@ -4,7 +4,7 @@ module Minitest
       module Code
 
         def self.color?
-          color_terminal = ENV['TERM'].to_s.downcase.index("color")
+          color_terminal = ENV['TERM'].to_s.downcase.include?("color")
           $stdout.tty? || color_terminal
         end
 

--- a/lib/minitest/reporters/ansi.rb
+++ b/lib/minitest/reporters/ansi.rb
@@ -2,7 +2,13 @@ module Minitest
   module Reporters
     module ANSI
       module Code
-        if ($stdout.tty?)
+
+        def self.color?
+          color_terminal = ENV['TERM'].to_s.downcase.index("color")
+          $stdout.tty? || color_terminal
+        end
+
+        if color?
           require 'ansi/code'
 
           include ::ANSI::Code


### PR DESCRIPTION
When using minitest-reporters in an environment where you can't easily have a TTY, such as using it with the https://github.com/ddollar/foreman gem, falling back to detecting if the terminal supports colors gets colors working again.

