### PR TITLE
Make minitest's SIGINFO handler work with minitest-reporters

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -35,6 +35,10 @@ module Minitest
         after_suite(tests.last.class)
       end
 
+      def to_s
+        report
+      end
+
       protected
 
       def after_suite(test)


### PR DESCRIPTION
When `minitest` receives a SIGINFO, it reports the failures that happened so we don't have to wait for all the tests to finish to see which ones broke.
Making `#to_s` call `#report` makes this feature work `minitest-reporters` as well.

That's how it looks when I hit `Ctrl-t` during a test run, before this patch:
![screenshot 2015-05-11 14 41 30](https://cloud.githubusercontent.com/assets/183363/7571170/1a16c774-f7ec-11e4-94e6-95a05448dad7.png)

That's how it looks after the patch:
![screenshot 2015-05-11 14 42 19](https://cloud.githubusercontent.com/assets/183363/7571195/4946d2aa-f7ec-11e4-8396-a30bc3441a02.png)
