### PR TITLE
Make minitest's SIGINFO handler work with DefaultReporter

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -121,6 +121,8 @@ module Minitest
         puts
       end
 
+      alias to_s report
+
       def print_failure(test)
         puts colored_for(result(test), message_for(test))
       end


### PR DESCRIPTION
When minitest receives a `SIGINFO`, it reports the failures that happened so we don't have to wait for all the tests to finish to see which ones broke.
Aliasing `to_s` to `report` makes this feature work with the `DefaultReporter` as well.

Before:
![screenshot 2015-05-11 14 41 30](https://cloud.githubusercontent.com/assets/183363/7592877/67cb6202-f8ac-11e4-8f82-d6b0e285265c.png)

After:
![screenshot 2015-05-11 14 42 19](https://cloud.githubusercontent.com/assets/183363/7592878/69a633f4-f8ac-11e4-91ad-4ab3aa31bf4f.png)
