### PR TITLE
Ensure old ActiveSupport fix works in all versions

### DIFF
--- a/lib/minitest/old_activesupport_fix.rb
+++ b/lib/minitest/old_activesupport_fix.rb
@@ -3,7 +3,10 @@ require "active_support/testing/setup_and_teardown"
 module ActiveSupport
   module Testing
     module SetupAndTeardown
-      module ForMinitest
+      if defined?(ForMinitest)
+        ForMiniTest = ForMinitest
+      end
+      module ForMiniTest
         remove_method :run
 
         def before_setup


### PR DESCRIPTION
ActiveSupport 3.2.18 renamed `ForMinitest` to `ForMiniTest` which breaks this
monkey patch. Aliasing the old `ForMinitest` to `ForMiniTest` before fixing the
problem corrects this issue.

This has been tested on ActiveSupport 3.2.17, 3.2.18 and 3.2.21 (the version on
which I originally encountered the problem).

Fixes #91.