### PR TITLE
Update spec_reporter.rb

### DIFF
--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -30,7 +30,7 @@ module Minitest
         super
         print pad_test(test.name)
         print_colored_status(test)
-        print(" (%.2fs)" % test.time)
+        print(" (%.2fs)" % test.time) unless test.time.nil?
         puts
         if !test.skipped? && test.failure
           print_info(test.failure)


### PR DESCRIPTION
Added check for test.time.nil? to prevent spec_reporter from breaking when using rails-perftest gem.
 
ERROR: /.rvm/gems/ruby-2.1.4-railsexpress/gems/minitest-reporters-1.0.11/lib/minitest/reporters/spec_reporter.rb:33:in `%': can't convert nil into Float (TypeError)
