### PR TITLE
Quit printing exception backtrace twice

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -86,8 +86,12 @@ module Minitest
       end
 
       def print_info(e, name=true)
-        print "#{e.exception.class.to_s}: " if name
-        e.message.each_line { |line| print_with_info_padding(line) }
+        if e.is_a?(Minitest::UnexpectedError)
+          message = "#{e.exception.class.to_s}: #{e.exception.message}"
+          message.each_line { |line| print_with_info_padding(line) }
+        else
+          e.message.each_line { |line| print_with_info_padding(line) }
+        end
 
         trace = filter_backtrace(e.backtrace)
         trace.each { |line| print_with_info_padding(line) }


### PR DESCRIPTION
This makes it so that exception backtrace is printed to stdout only once. Looks like this annoying problem has been around for some time. More info inline.

@os97673 @grosser