### PR TITLE
Fixed redundant spacing when using fast_fail option

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -126,7 +126,7 @@ module Minitest
       def print_failure(test)
         message = message_for(test)
         unless message.nil? || message.strip == ''
-          puts colored_for(result(test), message_for(test))
+          puts colored_for(result(test), message)
           puts
         end
       end

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -50,6 +50,7 @@ module Minitest
 
         print "#{"%.2f" % test.time} = " if options[:verbose]
 
+        # Print the pass/skip/fail mark
         print(if test.passed?
           record_pass(test)
         elsif test.skipped?
@@ -58,8 +59,8 @@ module Minitest
           record_failure(test)
         end)
 
+        # Print fast_fail information
         if @fast_fail && (test.skipped? || test.failure)
-          puts
           print_failure(test)
         end
       end
@@ -126,8 +127,8 @@ module Minitest
       def print_failure(test)
         message = message_for(test)
         unless message.nil? || message.strip == ''
-          puts colored_for(result(test), message)
           puts
+          puts colored_for(result(test), message)
         end
       end
 

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -84,10 +84,10 @@ module Minitest
         puts
         puts
         puts colored_for(suite_result, status_line)
+        puts
 
         unless @fast_fail
           tests.reject(&:passed?).each do |test|
-            puts
             print_failure(test)
           end
         end
@@ -124,7 +124,11 @@ module Minitest
       alias to_s report
 
       def print_failure(test)
-        puts colored_for(result(test), message_for(test))
+        message = message_for(test)
+        unless message.nil? || message.strip == ''
+          puts colored_for(result(test), message_for(test))
+          puts
+        end
       end
 
       private


### PR DESCRIPTION
Output when using fast_fail options with skipped tests prints out redundant newlines.  For example:

```ruby
# Running tests with run options --seed 58301:

..............S....................S.........................................SSSSSSSSSSSSSSSS..

Finished tests in 22.954128s, 4.1387 tests/s, 7.1447 assertions/s.




















95 tests, 164 assertions, 0 failures, 0 errors, 18 skips
```

Looks like the newline in the default reporter is out of place.  Also, `message_for` should probably allow for empty messages so that it can be easily overridden without redundant newlines.  I've patched it so the new output looks as follows:

```ruby
# Running tests with run options --seed 5569:

.............S....................S.........................................SSSSSSSSSSSSSSSS...

Finished tests in 23.166914s, 4.1007 tests/s, 7.0791 assertions/s.


95 tests, 164 assertions, 0 failures, 0 errors, 18 skips
```
