### PR TITLE
add an option to JUnitReporter to write the output to a single xml file

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -28,7 +28,7 @@ module Minitest
         suites = tests.group_by(&:class)
 
         if @single_file
-          write_xml_file_for("minitest", suites.values.flatten)
+          write_xml_file_for("minitest", tests.group_by(&:class).values.flatten)
         else
           suites.each do |suite, tests|
             write_xml_file_for(suite, tests)


### PR DESCRIPTION
With this Pull Request, you can initialize the JUnitReporter to write its output to a single xml file instead of one xml file per test suite. This can be useful to simplify or speed up CI parsing.

eg:
```ruby
require "minitest/reporters"
Minitest::Reporters.use! Minitest::Reporters::JUnitReporter.new('reports/path', single_file: true)
```

In the process I also changed the position `empty = true` argument to a keyword argument.

* What do you think would be an appropriate name for the option flag? 
* Is it ok to use keyword arguments? Or should I rewrite it to use a ruby 1.9 style options hash?