### PR TITLE
Adding an html reporter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,10 +22,10 @@ end
 # - RubyMineReporter must be tested separately inside of RubyMine
 # - JUnitReporter normally writes to `test/reports` instead of stdout
 task :gallery do
-  # unless rubymine_home
-  #   warn "To see RubyMineReporter supply RUBYMINE_HOME= or git clone git://git.jetbrains.org/idea/contrib.git ../rubymine-contrib"
-  #   exit 1
-  # end
+  unless rubymine_home
+    warn "To see RubyMineReporter supply RUBYMINE_HOME= or git clone git://git.jetbrains.org/idea/contrib.git ../rubymine-contrib"
+    exit 1
+  end
 
   [
     "Pride",

--- a/Rakefile
+++ b/Rakefile
@@ -22,10 +22,10 @@ end
 # - RubyMineReporter must be tested separately inside of RubyMine
 # - JUnitReporter normally writes to `test/reports` instead of stdout
 task :gallery do
-  unless rubymine_home
-    warn "To see RubyMineReporter supply RUBYMINE_HOME= or git clone git://git.jetbrains.org/idea/contrib.git ../rubymine-contrib"
-    exit 1
-  end
+  # unless rubymine_home
+  #   warn "To see RubyMineReporter supply RUBYMINE_HOME= or git clone git://git.jetbrains.org/idea/contrib.git ../rubymine-contrib"
+  #   exit 1
+  # end
 
   [
     "Pride",
@@ -34,7 +34,8 @@ task :gallery do
     "ProgressReporter",
     "RubyMateReporter",
     "SpecReporter",
-    "RubyMineReporter"
+    "RubyMineReporter",
+    "HtmlReporter"
   ].each do |reporter|
     puts
     puts "-" * 72

--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -15,6 +15,7 @@ module Minitest
     autoload :RubyMateReporter, "minitest/reporters/ruby_mate_reporter"
     autoload :RubyMineReporter, "minitest/reporters/rubymine_reporter"
     autoload :JUnitReporter, "minitest/reporters/junit_reporter"
+    autoload :HtmlReporter, "minitest/reporters/html_reporter"
 
     class << self
       attr_accessor :reporters

--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -13,8 +13,8 @@ module Minitest
     #
     # On each test run all files in the reports directory are deleted, this prevents a build up of old reports
     #
-    # The report is generated using using ERB. A custom ERB template can be provided but it is not required
-    # The default ERB template uses JQuery and Boostrap, both of these are included by referencing the CDN sites
+    # The report is generated using ERB. A custom ERB template can be provided but it is not required
+    # The default ERB template uses JQuery and Bootstrap, both of these are included by referencing the CDN sites
     class HtmlReporter < BaseReporter
 
       # The title of the report
@@ -56,10 +56,10 @@ module Minitest
         super({})
 
         defaults = {
-            :title    => 'Test Results',
-            :erb_template    => "#{File.dirname(__FILE__)}/../templates/index.html.erb",
-            :reports_dir => 'test/html_reports',
-            :mode => :safe
+            :title        => 'Test Results',
+            :erb_template => "#{File.dirname(__FILE__)}/../templates/index.html.erb",
+            :reports_dir  => 'test/html_reports',
+            :mode         => :safe
         }
 
         settings = defaults.merge(args)

--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -1,0 +1,160 @@
+require 'builder'
+require 'fileutils'
+require 'erb'
+
+module Minitest
+  module Reporters
+    class HtmlReporter < BaseReporter
+
+      attr_reader :title
+
+      def initialize(title = 'Test Results', reports_dir = "test/html_reports", empty = true)
+        super({})
+        @title = title
+        @reports_path = File.absolute_path(reports_dir)
+
+        if empty
+          puts "Emptying #{@reports_path}"
+          FileUtils.remove_dir(@reports_path) if File.exists?(@reports_path)
+          FileUtils.mkdir_p(@reports_path)
+        end
+      end
+
+      def report
+        super
+
+        puts "Writing HTML reports to #{@reports_path}"
+        erb_file = "#{File.dirname(__FILE__)}/../templates/index.html.erb"
+        html_file = @reports_path + "/index.html"
+        erb_str = File.read(erb_file)
+        renderer = ERB.new(erb_str)
+
+        tests_by_suites = tests.group_by(&:class) # taken from the JUnit reporter
+
+        suites = tests_by_suites.map do |suite, tests|
+          suite_summary = summarize_suite(suite, tests)
+          suite_summary[:tests] = tests.sort { |a, b| compare_tests(a, b) }
+          suite_summary
+        end
+
+        suites.sort! { |a, b| compare_suites(a, b) }
+
+        result = renderer.result(binding)
+        File.open(html_file, 'w') do |f|
+          f.write(result)
+        end
+      end
+
+      def passes
+        count - failures - errors - skips
+      end
+
+      def percent_passes
+        100 - percent_skipps - percent_errors_failures # prevetns rounding errors
+      end
+
+      def percent_skipps
+        (skips/count.to_f * 100).to_i
+      end
+
+      def percent_errors_failures
+        ((errors+failures)/count.to_f * 100).to_i
+      end
+
+      def compare_suites_by_name(suite_a, suite_b)
+        suite_a[:name] <=> suite_b[:name]
+      end
+
+      def compare_tests_by_name(test_a, test_b)
+        friendly_name(test_a) <=> friendly_name(test_b)
+      end
+
+      def compare_suites(suite_a, suite_b)
+        return compare_suites_by_name(suite_a, suite_b) if suite_a[:has_errors_or_failures] && suite_b[:has_errors_or_failures]
+        return -1 if suite_a[:has_errors_or_failures] && !suite_b[:has_errors_or_failures]
+        return 1 if !suite_a[:has_errors_or_failures] && suite_b[:has_errors_or_failures]
+
+        return compare_suites_by_name(suite_a, suite_b) if suite_a[:has_skipps] && suite_b[:has_skipps]
+        return -1 if suite_a[:has_skipps] && !suite_b[:has_skipps]
+        return 1 if !suite_a[:has_skipps] && suite_b[:has_skipps]
+
+        compare_suites_by_name(suite_a, suite_b)
+      end
+
+      def compare_tests(test_a, test_b)
+        return compare_tests_by_name(test_a, test_b) if test_fail_or_error?(test_a) && test_fail_or_error?(test_b)
+
+        return -1 if test_fail_or_error?(test_a) && !test_fail_or_error?(test_b)
+        return 1 if !test_fail_or_error?(test_a) && test_fail_or_error?(test_b)
+
+        return compare_tests_by_name(test_a, test_b) if test_a.skipped? && test_b.skipped?
+        return -1 if test_a.skipped? && !test_b.skipped?
+        return 1 if !test_a.skipped? && test_b.skipped?
+
+        compare_tests_by_name(test_a, test_b)
+      end
+
+      def test_fail_or_error?(test)
+        test.error? || test.failure
+      end
+
+      def friendly_name(test)
+        groups = test.name.scan(/(test_\d+_)(.*)/i)
+        return test.name if groups.empty?
+        "it #{groups[0][1]}"
+      end
+
+      # based on analyze_suite from the JUnit reporter
+      def summarize_suite(suite, tests)
+        summary = Hash.new(0)
+        summary[:name] = suite.to_s
+        tests.each do |test|
+          summary[:"#{result(test)}_count"] += 1
+          summary[:assertion_count] += test.assertions
+          summary[:test_count] += 1
+          summary[:time] += test.time
+        end
+        summary[:has_errors_or_failures] = (summary[:fail_count] + summary[:error_count]) > 0
+        summary[:has_skipps] = summary[:skip_count] > 0
+        summary
+      end
+
+      # based on message_for(test) from the JUnit reporter
+      def message_for(test)
+        suite = test.class
+        name = test.name
+        e = test.failure
+
+        if test.passed?
+          nil
+        elsif test.skipped?
+          "Skipped:\n#{name}(#{suite}) [#{location(e)}]:\n#{e.message}\n"
+        elsif test.failure
+          "Failure:\n#{name}(#{suite}) [#{location(e)}]:\n#{e.message}\n"
+        elsif test.error?
+          "Error:\n#{name}(#{suite}):\n#{e.message}"
+        end
+      end
+
+      # taken from the JUnit reporter
+      def location(exception)
+        last_before_assertion = ''
+        exception.backtrace.reverse_each do |s|
+          break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
+          last_before_assertion = s
+        end
+        last_before_assertion.sub(/:in .*$/, '')
+      end
+
+      def total_time_to_hms
+        return ('%.2fs' % total_time) if total_time < 1
+
+        hours = total_time / (60 * 60)
+        minutes = ((total_time / 60) % 60).to_s.rjust(2,'0')
+        seconds = (total_time % 60).to_s.rjust(2,'0')
+
+        "#{ hours }h#{ minutes }m#{ seconds }s"
+      end
+    end
+  end
+end

--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -4,62 +4,111 @@ require 'erb'
 
 module Minitest
   module Reporters
+    # A reporter for generating HTML test reports
+    # This is recommended be used with a CI server, where the report is kept as an artifact and is accessible via a shared link
+    #
+    # By default the reports are saved to 'test/html_reports'
+    # The reporter sorts the results alphabetically and then by failing tests
+    #
+    # When using Minitest Specs, the number prefeix is dropped from the name of the test, so that it reads well
+    #
+    # This is built using ERB and a custom ERB template can be provided
+    # On each test run, all files in the reports directory are deleted, this prevents a build up of old reports
+    #
+    # The constructor takes a hash, and uses the following keys:
+    # :title - the title that will be used in the report, defaults to 'Test Results'
+    # :reports_dir - the directory the reports should be written to, defaults to 'test/html_reports'
+    # :erb_template - the path to a custom ERB template, defaults to the supplied ERB template
+    # :mode - Useful for debugging, :terse suppresses errors and is the default, :verbose lets errors bubble up
     class HtmlReporter < BaseReporter
 
       attr_reader :title
 
-      def initialize(title = 'Test Results', reports_dir = "test/html_reports", empty = true)
+      def initialize(args)
         super({})
-        @title = title
+
+        defaults = {
+            :title    => 'Test Results',
+            :erb_template    => "#{File.dirname(__FILE__)}/../templates/index.html.erb",
+            :reports_dir => 'test/html_reports',
+            :mode => :safe
+        }
+
+        settings = defaults.merge(args)
+
+        @mode = settings[:mode]
+        @title = settings[:title]
+        @erb_template = settings[:erb_template]
+        reports_dir = settings[:reports_dir]
+
         @reports_path = File.absolute_path(reports_dir)
 
-        if empty
-          puts "Emptying #{@reports_path}"
-          FileUtils.remove_dir(@reports_path) if File.exists?(@reports_path)
-          FileUtils.mkdir_p(@reports_path)
-        end
+        puts "Emptying #{@reports_path}"
+        FileUtils.remove_dir(@reports_path) if File.exists?(@reports_path)
+        FileUtils.mkdir_p(@reports_path)
       end
 
       def report
         super
 
-        puts "Writing HTML reports to #{@reports_path}"
-        erb_file = "#{File.dirname(__FILE__)}/../templates/index.html.erb"
-        html_file = @reports_path + "/index.html"
-        erb_str = File.read(erb_file)
-        renderer = ERB.new(erb_str)
+        begin
 
-        tests_by_suites = tests.group_by(&:class) # taken from the JUnit reporter
+          puts "Writing HTML reports to #{@reports_path}"
+          html_file = @reports_path + "/index.html"
+          erb_str = File.read(@erb_template)
+          renderer = ERB.new(erb_str)
 
-        suites = tests_by_suites.map do |suite, tests|
-          suite_summary = summarize_suite(suite, tests)
-          suite_summary[:tests] = tests.sort { |a, b| compare_tests(a, b) }
-          suite_summary
+          tests_by_suites = tests.group_by(&:class) # taken from the JUnit reporter
+
+          suites = tests_by_suites.map do |suite, tests|
+            suite_summary = summarize_suite(suite, tests)
+            suite_summary[:tests] = tests.sort { |a, b| compare_tests(a, b) }
+            suite_summary
+          end
+
+          suites.sort! { |a, b| compare_suites(a, b) }
+
+          result = renderer.result(binding)
+          File.open(html_file, 'w') do |f|
+            f.write(result)
+          end
+
+        rescue Exception => e
+          puts 'There was an error writting the HTML report'
+          puts 'Use mode => :verbose in the HTML reporters constructor to see more detail' if @mode == :terse
+          raise e if @mode != :terse
         end
 
-        suites.sort! { |a, b| compare_suites(a, b) }
-
-        result = renderer.result(binding)
-        File.open(html_file, 'w') do |f|
-          f.write(result)
-        end
       end
 
+      # The number of tests that passed
       def passes
         count - failures - errors - skips
       end
 
+      # The percentage of tests that passed, adjusted to handle rounding errors
       def percent_passes
-        100 - percent_skipps - percent_errors_failures # prevetns rounding errors
+        100 - percent_skipps - percent_errors_failures
       end
 
+      # The percentage of tests that were skipped
       def percent_skipps
         (skips/count.to_f * 100).to_i
       end
 
+      # The percentage of tests that failed
       def percent_errors_failures
         ((errors+failures)/count.to_f * 100).to_i
       end
+
+      # Trims off the number prefix on test names when using Minitest Specs
+      def friendly_name(test)
+        groups = test.name.scan(/(test_\d+_)(.*)/i)
+        return test.name if groups.empty?
+        "it #{groups[0][1]}"
+      end
+
+      private
 
       def compare_suites_by_name(suite_a, suite_b)
         suite_a[:name] <=> suite_b[:name]
@@ -98,11 +147,7 @@ module Minitest
         test.error? || test.failure
       end
 
-      def friendly_name(test)
-        groups = test.name.scan(/(test_\d+_)(.*)/i)
-        return test.name if groups.empty?
-        "it #{groups[0][1]}"
-      end
+
 
       # based on analyze_suite from the JUnit reporter
       def summarize_suite(suite, tests)

--- a/lib/minitest/templates/index.html.erb
+++ b/lib/minitest/templates/index.html.erb
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title><%= title %></title>
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
+</head>
+
+<body>
+<div class="container">
+    <div class="jumbotron">
+        <h1><%= title %></h1>
+        <p>
+            Finished in <%= total_time_to_hms %>, <%= '%.2f tests/s' % (count / total_time) %>, <%= '%.2f assertions/s' % (assertions / total_time) %>
+        </p>
+        <p>
+            <strong>
+            <span class="<%= 'text-info' if (failures == 0 && errors == 0) %>"><%= '%d' % count %> tests</span>,
+            <span class="<%= 'text-info' if (failures == 0 && errors == 0) %>"> <%= '%d' % assertions %> assertions</span>,
+            <span class="<%= 'text-danger' if failures > 0 %>"> <%= '%d' % failures %> failures</span>,
+            <span class="<%= 'text-danger' if errors > 0 %>"> <%= '%d' % errors %> errors</span>,
+            <span class="<%= 'text-warning' if skips > 0 %>"> <%= '%d' % skips %> skips</span>
+            </strong>
+        </p>
+
+        <div class="progress">
+            <div class="progress-bar progress-bar-info" style="width: <%= percent_passes %>%">
+                <%= '%d' % percent_passes %>% passed
+            </div>
+            <div class="progress-bar progress-bar-danger" style="width: <%= percent_errors_failures %>%">
+                <%= '%d' % percent_errors_failures %>% failed
+            </div>
+            <div class="progress-bar progress-bar-warning" style="width: <%= percent_skipps %>%">
+                <%= '%d' % percent_skipps %>% skipped
+            </div>
+        </div>
+
+
+    </div>
+
+    <% suites.each do |suite| %>
+        <div class="panel panel-default">
+            <div class="panel-heading"><strong><%= suite[:name] %></strong>
+                <span class="pull-right">
+                    <span class="<%= 'text-info' if (suite[:fail_count] == 0 && suite[:error_count] == 0) %>"><%= '%d' % suite[:test_count] %> tests</span>,
+                    <span class="<%= 'text-info' if (failures == 0 && errors == 0) %>"> <%= '%d' % suite[:assertion_count] %> assertions</span>,
+                    <span class="<%= 'text-danger' if suite[:fail_count] > 0 %>"> <%= '%d' % suite[:fail_count] %> failures</span>,
+                    <span class="<%= 'text-danger' if suite[:error_count] > 0 %>"> <%= '%d' % suite[:error_count] %> errors</span>,
+                    <span class="<%= 'text-warning' if suite[:skip_count] > 0 %>"> <%= '%d' % suite[:skip_count] %> skips</span>,
+                    <span> finished in <%= '%.4fs' % suite[:time] %></span>
+                </span>
+            </div>
+            <div class="panel-body">
+                <div class="list-group">
+                    <% suite[:tests].each do |test| %>
+                        <div class="list-group-item">
+                            <h5 class="list-group-item-heading">
+                                <% if result(test) == :pass %>
+                                    <span class="glyphicon glyphicon-ok text-info" aria-hidden="true"></span>
+                                <% elsif result(test) == :skip %>
+                                    <span class="glyphicon glyphicon-ban-circle text-warning" aria-hidden="true"></span>
+                                <% else %>
+                                    <span class="glyphicon glyphicon-remove text-danger"  aria-hidden="true"></span>
+                                <% end %>
+                                <%= friendly_name(test) %>
+                                <span class="pull-right">
+                                    Assertions <%= test.assertions %>, time <%= ('%.6fs' % test.time) %>
+                                </span>
+                            </h5>
+                            <% if !test.passed? %>
+                                <pre class="list-group-item-text"><%= "#{location(test.failure)}\n\n#{test.failure.message}" %></pre>
+                            <% end %>
+                        </div>
+                    <% end %>
+                </div>
+            </div>
+        </div>
+    <% end %>
+</div>
+</body>
+</html>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,5 +17,5 @@ elsif ENV["REPORTER"]
   reporter_klass = Minitest::Reporters.const_get(ENV["REPORTER"])
   Minitest::Reporters.use!(reporter_klass.new)
 else
-  Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new)
+  Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new, Minitest::Reporters::JUnitReporter.new, Minitest::Reporters::HtmlReporter.new('Sample Tests')]
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,5 +17,5 @@ elsif ENV["REPORTER"]
   reporter_klass = Minitest::Reporters.const_get(ENV["REPORTER"])
   Minitest::Reporters.use!(reporter_klass.new)
 else
-  Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new, Minitest::Reporters::JUnitReporter.new, Minitest::Reporters::HtmlReporter.new(:title => 'Test Samples')]
+  Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new)
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,5 +17,5 @@ elsif ENV["REPORTER"]
   reporter_klass = Minitest::Reporters.const_get(ENV["REPORTER"])
   Minitest::Reporters.use!(reporter_klass.new)
 else
-  Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new, Minitest::Reporters::JUnitReporter.new, Minitest::Reporters::HtmlReporter.new('Sample Tests')]
+  Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new, Minitest::Reporters::JUnitReporter.new, Minitest::Reporters::HtmlReporter.new(:title => 'Test Samples')]
 end


### PR DESCRIPTION
This reporter generates HTML output. 

The report uses bootstrap and JQuery. These files have not been checked in, as they are included in the header section of the report by referencing the CDN sites.

The html file is generated by using ERB. The template is found at templates/index.html.erb.

This works with mintest unit tests and minitest specs. When using minitest specs, the name of the test is slightly modified. It removes the test index so that the report reads slightly better.

The suites\tests are ordered alphabetically and then ordered so that failed test suites\tests are at the top, followed by skipped and then passing tests.   

I am more than willing to make any changes you suggest. 

Thanks, Daryn 