### PR TITLE
Quit printing exception backtrace twice, revisited

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -89,8 +89,12 @@ module Minitest
         print "#{e.exception.class.to_s}: " if name
         e.message.each_line { |line| print_with_info_padding(line) }
 
-        trace = filter_backtrace(e.backtrace)
-        trace.each { |line| print_with_info_padding(line) }
+        # When e is a Minitest::UnexpectedError, the filtered backtrace is already part of the message printed out
+        # by the previous line. In that case, and that case only, skip the backtrace output.
+        unless e.is_a?(MiniTest::UnexpectedError)
+          trace = filter_backtrace(e.backtrace)
+          trace.each { |line| print_with_info_padding(line) }
+        end
       end
     end
   end


### PR DESCRIPTION
Improves [a fix previously proposed by Gaurav Chande](https://github.com/kern/minitest-reporters/pull/157).

Original comment:
This makes it so that exception backtrace is printed to stdout only
once. Looks like this annoying problem has been around for some time.