### PR TITLE
Disable custom formatters when running under vim

### DIFF
--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -58,7 +58,7 @@ module Minitest
         [RubyMateReporter.new]
       elsif env["RM_INFO"] || env["TEAMCITY_VERSION"]
         [RubyMineReporter.new]
-      else
+      elsif !env["VIM"]
         Array(console_reporters)
       end
     end

--- a/test/unit/minitest/reporters_test.rb
+++ b/test/unit/minitest/reporters_test.rb
@@ -24,5 +24,11 @@ module MinitestReportersTest
       reporters = Minitest::Reporters.choose_reporters [Minitest::Reporters::SpecReporter.new], {}
       assert_instance_of Minitest::Reporters::SpecReporter, reporters[0]
     end
+
+    def test_chooses_no_reporters_when_running_under_vim
+      reporters = Minitest::Reporters.choose_reporters(
+        [Minitest::Reporters::DefaultReporter.new], { "VIM" => "/usr/share/vim" })
+      assert_equal nil, reporters
+    end
   end
 end


### PR DESCRIPTION
* Vim's quickfix list does not support color codes and only recognizes errors from the
  default Minitest output formatter.