### PR TITLE
fix NoMethodError

### DIFF
--- a/lib/minitest/minitest_reporter_plugin.rb
+++ b/lib/minitest/minitest_reporter_plugin.rb
@@ -1,3 +1,5 @@
+require 'minitest/reporters'
+
 module Minitest
   module Reporters
     class DelegateReporter


### PR DESCRIPTION
lib/minitest/minitest_reporter_plugin.rb:49:in `all_reporters': undefined method `reporters' for Minitest::Reporters:Module (NoMethodError)