### PR TITLE
Prevent SpecReporter from changing test name

### DIFF
--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -28,8 +28,8 @@ module Minitest
 
       def record(test)
         super
-        test.name.gsub!(/^test_:/, 'test:')
-        print pad_test(test.name)
+        test_name = test.name.gsub(/^test_: /, 'test:')
+        print pad_test(test_name)
         print_colored_status(test)
         print(" (%.2fs)" % test.time) unless test.time.nil?
         puts

--- a/test/unit/minitest/spec_reporter_test.rb
+++ b/test/unit/minitest/spec_reporter_test.rb
@@ -23,5 +23,19 @@ module MinitestReportersTest
         @reporter.record(@test)
       end
     end
+
+    def test_responds_to_test_name_after_record
+      test_name = 'test_: Should foo'
+      the_test_class = Class.new(Minitest::Test) do
+        define_method test_name do
+          assert(false)
+        end
+      end
+      the_test = the_test_class.new('')
+      the_test.name = test_name
+      @reporter.io = StringIO.new
+      @reporter.record(the_test)
+      assert_respond_to the_test, the_test.name
+    end
   end
 end


### PR DESCRIPTION
#156 made SpecReporter#record to change test name which is made by shoulda.

But rails5.x [gets source locations of failed tests with test name](https://github.com/rails/rails/blob/ccee7eea8e5a8a34256467dd1096ac549dd17362/railties/lib/rails/test_unit/reporter.rb#L17).

Then, with rails(edge) + minitest(5.8.0) + SpecReporter(1.1.2) + shoulda(3.5.0), NameError raises when printing failed tests.

This commit will fix it. 