### PR TITLE
Add 'Last' run time to report;

### DIFF
--- a/lib/minitest/reporters/mean_time_reporter.rb
+++ b/lib/minitest/reporters/mean_time_reporter.rb
@@ -94,7 +94,7 @@ module Minitest
       #   run.
       def defaults
         {
-          count:                  15,
+          show_count:             15,
           previous_runs_filename: '/tmp/minitest_reporters_previous_run',
           report_filename:        '/tmp/minitest_reporters_report',
         }
@@ -138,8 +138,8 @@ module Minitest
 
       # @return [Fixnum] The number of tests to output to output to the screen
       #   after each run.
-      def count
-        options[:count]
+      def show_count
+        options[:show_count]
       end
 
       # @return [Hash<String => Array<Float>]
@@ -233,14 +233,14 @@ module Minitest
         File.write(report_filename, report_title + report_body)
       end
 
-      # Writes a number of tests (configured via the 'count' option) to the
+      # Writes a number of tests (configured via the 'show_count' option) to the
       # screen after creating the report. See '#create_new_report!' for example
       # output information.
       #
       # @return [void]
       def write_to_screen!
         puts report_title
-        puts report_body.lines.take(count)
+        puts report_body.lines.take(show_count)
       end
 
       # @return [String] A yellow 'Avg:' label.

--- a/lib/minitest/reporters/mean_time_reporter.rb
+++ b/lib/minitest/reporters/mean_time_reporter.rb
@@ -245,32 +245,32 @@ module Minitest
 
       # @return [String] A yellow 'Avg:' label.
       def avg_label
-        "\e[33mAvg:\e[39m"
+        ANSI::Code.yellow('Avg:')
       end
 
       # @return [String] A blue 'Description:' label.
       def des_label
-        "\e[34mDescription:\e[39m"
+        ANSI::Code.blue('Description:')
       end
 
       # @return [String] A red 'Max:' label.
       def max_label
-        "\e[31mMax:\e[39m"
+        ANSI::Code.red('Max:')
       end
 
       # @return [String] A green 'Min:' label.
       def min_label
-        "\e[32mMin:\e[39m"
+        ANSI::Code.green('Min:')
       end
 
       # @param rating [Symbol] One of :faster, :slower or :inconclusive.
       # @return [String] A purple 'Last:' label.
       def run_label(rating)
         case rating
-        when :faster then "\e[92mLast:\e[39m"
-        when :slower then "\e[91mLast:\e[39m"
+        when :faster then ANSI::Code.green('Last:')
+        when :slower then ANSI::Code.red('Last:')
         else
-          "\e[35mLast:\e[39m"
+          ANSI::Code.magenta('Last:')
         end
       end
 

--- a/lib/minitest/reporters/mean_time_reporter.rb
+++ b/lib/minitest/reporters/mean_time_reporter.rb
@@ -119,10 +119,14 @@ module Minitest
           avg  = (sum / size).round(9).to_s.ljust(12)
           min  = Array(timings).min.to_s.ljust(12)
           max  = Array(timings).max.to_s.ljust(12)
+          run  = Array(timings).last.to_s.ljust(12)
+
+          rating = rate(run, min, max)
 
           obj << "#{avg_label} #{avg} " \
                  "#{min_label} #{min} " \
                  "#{max_label} #{max} " \
+                 "#{run_label(rating)} #{run} " \
                  "#{des_label} #{description}\n"
         end.sort.reverse.join
       end
@@ -213,11 +217,16 @@ module Minitest
       # Creates a new report file in the 'report_filename'. This file contains
       # a line for each test of the following example format:
       #
-      # Avg: 0.0555555 Min: 0.0498765 Max: 0.0612345 Description: The test name
+      # Avg: 0.0555555 Min: 0.0498765 Max: 0.0612345 Last: 0.0499421 Description: The test name
       #
       # Note however the timings are to 9 decimal places, and padded to 12
       # characters and each label is coloured, Avg (yellow), Min (green),
-      # Max (red) and Description (blue). It looks pretty!
+      # Max (red), Last (multi), and Description (blue). It looks pretty!
+      #
+      # The 'Last' label is special in that it will be colour coded depending
+      # on whether the last run was faster (bright green) or slower (bright red)
+      # or inconclusive (purple). This helps to identify changes on a per run
+      # basis.
       #
       # @return [void]
       def create_new_report!
@@ -252,6 +261,31 @@ module Minitest
       # @return [String] A green 'Min:' label.
       def min_label
         "\e[32mMin:\e[39m"
+      end
+
+      # @param rating [Symbol] One of :faster, :slower or :inconclusive.
+      # @return [String] A purple 'Last:' label.
+      def run_label(rating)
+        case rating
+        when :faster then "\e[92mLast:\e[39m"
+        when :slower then "\e[91mLast:\e[39m"
+        else
+          "\e[35mLast:\e[39m"
+        end
+      end
+
+      # @param run [Float] The last run time.
+      # @param min [Float] The minimum run time.
+      # @param max [Float] The maximum run time.
+      # @return [Symbol] One of :faster, :slower or :inconclusive.
+      def rate(run, min, max)
+        if run == min
+          :faster
+        elsif run == max
+          :slower
+        else
+          :inconclusive
+        end
       end
 
     end


### PR DESCRIPTION
This provides the time the test took to run last time it was ran. The label changes colour to signify whether the last run set the new minimum (ie. faster; bright green) or set the new maximum (ie. slower; bright red). This helps to identify improvements or degradations on a per test basis, especially if you are focussing on this particular test/method as part of your refactor/optimisation cycle.