### PR TITLE
Rounding float values to integers have more value to humans

### DIFF
--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -204,9 +204,9 @@ module Minitest
       def total_time_to_hms
         return ('%.2fs' % total_time) if total_time < 1
 
-        hours = total_time / (60 * 60)
-        minutes = ((total_time / 60) % 60).to_s.rjust(2,'0')
-        seconds = (total_time % 60).to_s.rjust(2,'0')
+        hours = (total_time / (60 * 60)).round
+        minutes = ((total_time / 60) % 60).round.to_s.rjust(2,'0')
+        seconds = (total_time % 60).round.to_s.rjust(2,'0')
 
         "#{ hours }h#{ minutes }m#{ seconds }s"
       end


### PR DESCRIPTION
I assume a line like this:

`Finished in 0.0007811995047248072h0.04687197028348843m2.812318217009306s, 6.04 tests/s, 10.31 assertions/s`

would have more meaning in this form:

`Finished in 0h0m2s, 6.04 tests/s, 10.31 assertions/s`

so I have rounded those floats down in the report.