### PR TITLE
Fix a bug that RE-generated JUnit filenames differently

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -118,10 +118,11 @@ module Minitest
 
       def filename_for(suite)
         file_counter = 0
-        filename = "TEST-#{suite.to_s[0..240].gsub(/[^a-zA-Z0-9]+/, '-')}.xml" #restrict max filename length, to be kind to filesystems
+        suite_name = suite.to_s[0..240].gsub(/[^a-zA-Z0-9]+/, '-') # restrict max filename length, to be kind to filesystems
+        filename = "TEST-#{suite_name}.xml"
         while File.exists?(File.join(@reports_path, filename)) # restrict number of tries, to avoid infinite loops
           file_counter += 1
-          filename = "TEST-#{suite}-#{file_counter}.xml"
+          filename = "TEST-#{suite_name}-#{file_counter}.xml"
           puts "Too many duplicate files, overwriting earlier report #{filename}" and break if file_counter >= 99
         end
         File.join(@reports_path, filename)

--- a/test/fixtures/junit_filename_bug_example_test.rb
+++ b/test/fixtures/junit_filename_bug_example_test.rb
@@ -13,3 +13,9 @@ describe 'something/other' do
     1.must_equal 1
   end
 end
+
+describe 'something/other' do
+  it 'does something else' do
+    1.must_equal 2
+  end
+end


### PR DESCRIPTION
Related to #75.

If two describe blocks have the same description, JUnit creates the same
filename for them. To avoid overwriting reports, it adds a number to the
filename if it finds a file already existing.

Before this change, the filename with the number was generated
differently than the original filename-- namely, it did not include the
special character substitution or filename length limiting. Therefore,
if two describes were the same and both used special characters, the
second one would fail because its filename would be invalid.

To fix this, reuse the name generated without the special characters and
limited to a filesystem-friendly length, even when we're adding a number
to avoid filename collisions.