### PR TITLE
Implement DelegateReporter#io

### DIFF
--- a/lib/minitest/minitest_reporter_plugin.rb
+++ b/lib/minitest/minitest_reporter_plugin.rb
@@ -7,6 +7,10 @@ module Minitest
         @all_reporters = nil
       end
 
+      def io
+        @options[:io]
+      end
+
       def start
         all_reporters.each(&:start)
       end

--- a/test/unit/minitest/minitest_reporter_plugin_test.rb
+++ b/test/unit/minitest/minitest_reporter_plugin_test.rb
@@ -1,0 +1,14 @@
+require_relative "../../test_helper"
+
+module MinitestReportersTest
+  class MinitestReporterPluginTest < Minitest::Test
+    def test_delegates_io
+      reporter = Minitest::Reporters::DefaultReporter.new
+      io_handle = STDOUT
+      dr = Minitest::Reporters::DelegateReporter.new([ reporter ], :io => io_handle)
+      assert_equal io_handle, dr.io
+      dr.send :all_reporters
+      assert_equal io_handle, reporter.io
+    end
+  end
+end


### PR DESCRIPTION
This makes the duck type of DelegateReporter more similar to
Minitest::StatisticsReporter avoiding a crash if #io is called but not
delegated to one of the reporters. If the io option was passed to
DelegateReporter.new all of the reporters' io attributes should be
initialized to it anyway, so just return it.