### PR TITLE
Substitute `Time.now` for `Minitest.clock_time`;

### DIFF
--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -68,6 +68,18 @@ module Minitest
       end
     end
 
+    def self.clock_time
+      if minitest_version >= 561
+        Minitest.clock_time
+      else
+        Time.now
+      end
+    end
+
+    def self.minitest_version
+      Minitest::VERSION.gsub('.', '').to_i
+    end
+
     def self.use_old_activesupport_fix!
       if defined?(ActiveSupport::VERSION) && ActiveSupport::VERSION::MAJOR < 4
         require "minitest/old_activesupport_fix"

--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -66,7 +66,7 @@ module Minitest
       end
 
       def total_time
-        super || Time.now - start_time
+        super || Minitest.clock_time - start_time
       end
 
       def total_count

--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -66,7 +66,7 @@ module Minitest
       end
 
       def total_time
-        super || Minitest.clock_time - start_time
+        super || Minitest::Reporters.clock_time - start_time
       end
 
       def total_count

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -35,7 +35,7 @@ module Minitest
       end
 
       def before_suite(suite)
-        @suite_start_times[suite] = Minitest.clock_time
+        @suite_start_times[suite] = Minitest::Reporters.clock_time
         super
       end
 
@@ -208,7 +208,7 @@ module Minitest
         if start_time.nil?
           0
         else
-          Minitest.clock_time - start_time
+          Minitest::Reporters.clock_time - start_time
         end
       end
     end

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -35,7 +35,7 @@ module Minitest
       end
 
       def before_suite(suite)
-        @suite_start_times[suite] = Time.now
+        @suite_start_times[suite] = Minitest.clock_time
         super
       end
 
@@ -208,7 +208,7 @@ module Minitest
         if start_time.nil?
           0
         else
-          Time.now - start_time
+          Minitest.clock_time - start_time
         end
       end
     end

--- a/lib/minitest/reporters/mean_time_reporter.rb
+++ b/lib/minitest/reporters/mean_time_reporter.rb
@@ -117,9 +117,9 @@ module Minitest
           size = Array(timings).size
           sum  = Array(timings).inject { |total, x| total + x }
           avg  = (sum / size).round(9).to_s.ljust(12)
-          min  = Array(timings).min.to_s.ljust(12)
-          max  = Array(timings).max.to_s.ljust(12)
-          run  = Array(timings).last.to_s.ljust(12)
+          min  = Array(timings).min.round(9).to_s.ljust(12)
+          max  = Array(timings).max.round(9).to_s.ljust(12)
+          run  = Array(timings).last.round(9).to_s.ljust(12)
 
           rating = rate(run, min, max)
 

--- a/test/unit/minitest/reporters_test.rb
+++ b/test/unit/minitest/reporters_test.rb
@@ -30,5 +30,23 @@ module MinitestReportersTest
         [Minitest::Reporters::DefaultReporter.new], { "VIM" => "/usr/share/vim" })
       assert_equal nil, reporters
     end
+
+    def test_uses_minitest_clock_time_when_minitest_version_greater_than_561
+      Minitest::Reporters.stub :minitest_version, 583 do
+        Minitest.stub :clock_time, 6765.378751009 do
+          clock_time = Minitest::Reporters.clock_time
+          assert_equal 6765.378751009, clock_time
+        end
+      end
+    end
+
+    def test_uses_minitest_clock_time_when_minitest_version_less_than_561
+      Minitest::Reporters.stub :minitest_version, 431 do
+        Time.stub :now, Time.new(2015, 11, 20, 17, 35) do
+          clock_time = Minitest::Reporters.clock_time
+          assert_equal Time.new(2015, 11, 20, 17, 35), clock_time
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Minitest (since 5.6.1) uses `Minitest.clock_time` if `Process::CLOCK_MONOTONIC`
is available on the system. To avoid misreporting times, the implementation has
been changed to use this instead of `Time.now`.

Fixes #186.