### PR TITLE
Provide optional sorting for MeanTimeReporter;

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Minitest::Reporters::ProgressReporter # => Fuubar-like output with a progress ba
 Minitest::Reporters::RubyMateReporter # => Simple reporter designed for RubyMate
 Minitest::Reporters::RubyMineReporter # => Reporter designed for RubyMine IDE and TeamCity CI server
 Minitest::Reporters::JUnitReporter    # => JUnit test reporter designed for JetBrains TeamCity
+Minitest::Reporters::MeanTimeReporter # => Produces a report summary showing the slowest running tests
 ```
 
 Options can be passed to these reporters at construction-time, e.g. to force


### PR DESCRIPTION
Provide `:sort_column` and `:order` options;

The `:sort_column` option allows the report summary to be sorted by the Avg, Min, Max or Last column (using `:avg`, `:min`, `:max`, `:last`, respectively). e.g.

`sort_column: :max # => sorts the report summary by the Max column`

The `:order` option allows the report summary to be sorted in either ascending (`:asc` - fastest to slowest) or by default descending order (`:desc` - slowest to fastest).

`order: :asc # => sorts the report summary in ascending order (fastest to slowest)`