### PR TITLE
Improved SpecReporter output

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,48 +56,6 @@ Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(:color => tru
 ```
 
 
-## SpecReporter - configuration options ##
-
-The SpecReporter supports the customised output as highlighted below.
-
-By default the output would look something like this:
-
-```ruby
-"test_0001_should return the correct path                        PASS (0.00s)"
-```
-
-
-But the output can be changed via these configuration options:
-
- *  `:show_order`   - sets the output order (`:before` or `:after`) [ Default: `:after` ]
- 
- *  `:show_time`    - toggle for outputting the timer info.  [ Default: `true` ]
- 
- *  `:show_status`  - toggle for outputting the status info   [ Default: `true` ]
-
-By combining these options, the following output formats can be achieved:
-
-```ruby
-"should return the correct path"
-
-"should return the correct path  -  (0.00s)"
-
-"PASS   should return the correct path"
-
-"PASS   should return the correct path  -  (0.00s)"
-```
-
-Use as follows:
-
-```ruby
-Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new(:color => true, show_order: :before, ...)]
-
-```
-
-This can aid in the creation of spec documents from your test suite(s).
-
-
-
 ## Screenshots ##
 
 **Default Reporter**

--- a/README.md
+++ b/README.md
@@ -55,6 +55,49 @@ color output from `DefaultReporter`:
 Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(:color => true)]
 ```
 
+
+## SpecReporter - configuration options ##
+
+The SpecReporter supports the customised output as highlighted below.
+
+By default the output would look something like this:
+
+```ruby
+"test_0001_should return the correct path                        PASS (0.00s)"
+```
+
+
+But the output can be changed via these configuration options:
+
+ *  `:show_order`   - sets the output order (`:before` or `:after`) [ Default: `:after` ]
+ 
+ *  `:show_time`    - toggle for outputting the timer info.  [ Default: `true` ]
+ 
+ *  `:show_status`  - toggle for outputting the status info   [ Default: `true` ]
+
+By combining these options, the following output formats can be achieved:
+
+```ruby
+"should return the correct path"
+
+"should return the correct path  -  (0.00s)"
+
+"PASS   should return the correct path"
+
+"PASS   should return the correct path  -  (0.00s)"
+```
+
+Use as follows:
+
+```ruby
+Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new(:color => true, show_order: :before, ...)]
+
+```
+
+This can aid in the creation of spec documents from your test suite(s).
+
+
+
 ## Screenshots ##
 
 **Default Reporter**

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -10,6 +10,16 @@ module Minitest
       include ANSI::Code
       include RelativePosition
 
+      def initialize(options = {})
+        super
+        options = {
+          :show_order  => :after,
+          :show_time   => true,
+          :show_status => true
+        }.merge(options)
+        @options = options
+      end
+
       def start
         super
         puts('Started with run options %s' % options[:args])
@@ -28,10 +38,20 @@ module Minitest
 
       def record(test)
         super
-        test_name = test.name.gsub(/^test_: /, 'test:')
-        print pad_test(test_name)
-        print_colored_status(test)
-        print(" (%.2fs)" % test.time) unless test.time.nil?
+        if options[:show_order] == :before
+           print_colored_status(test) if options[:show_status]
+           test_name = test.name.gsub(/^test_(\d+_)?/, '  ')
+           print(test_name)
+           unless test.time.nil?
+             color = test.time > 0.1 ? :red : :white
+             print(send(color) { "  -  (%.2fs)" } % test.time) if options[:show_time]
+           end
+         else
+          test_name = test.name.gsub(/^test_: /, 'test:')
+          print pad_test(test_name)
+          print_colored_status(test)
+          print(" (%.2fs)" % test.time) unless test.time.nil?
+        end
         puts
         if !test.skipped? && test.failure
           print_info(test.failure)

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -38,20 +38,20 @@ module Minitest
 
       def record(test)
         super
-        if options[:show_order] == :before
-           print_colored_status(test) if options[:show_status]
-           test_name = test.name.gsub(/^test_(\d+_)?/, '  ')
-           print(test_name)
-           unless test.time.nil?
-             color = test.time > 0.1 ? :red : :white
-             print(send(color) { "  -  (%.2fs)" } % test.time) if options[:show_time]
-           end
-         else
+        # if options[:show_order] == :before
+        #    print_colored_status(test) if options[:show_status]
+        #    test_name = test.name.gsub(/^test_(\d+_)?/, '  ')
+        #    print(test_name)
+        #    unless test.time.nil?
+        #      color = test.time > 0.1 ? :red : :white
+        #      print(send(color) { "  -  (%.2fs)" } % test.time) if options[:show_time]
+        #    end
+        #  else
           test_name = test.name.gsub(/^test_: /, 'test:')
           print pad_test(test_name)
           print_colored_status(test)
           print(" (%.2fs)" % test.time) unless test.time.nil?
-        end
+        # end
         puts
         if !test.skipped? && test.failure
           print_info(test.failure)

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -10,15 +10,15 @@ module Minitest
       include ANSI::Code
       include RelativePosition
 
-      def initialize(options = {})
-        super
-        options = {
-          :show_order  => :after,
-          :show_time   => true,
-          :show_status => true
-        }.merge(options)
-        @options = options
-      end
+      # def initialize(options = {})
+      #   super
+      #   options = {
+      #     :show_order  => :after,
+      #     :show_time   => true,
+      #     :show_status => true
+      #   }.merge(options)
+      #   @options = options
+      # end
 
       def start
         super

--- a/minitest-reporters.gemspec
+++ b/minitest-reporters.gemspec
@@ -15,13 +15,14 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.rubyforge_project = 'minitest-reporters'
 
-  s.add_dependency 'minitest', '>= 5.0'
-  s.add_dependency 'ansi'
-  s.add_dependency 'ruby-progressbar'
-  s.add_dependency 'builder'
+  s.add_dependency 'minitest', '5.8.3'
+  s.add_dependency 'ansi', '1.5.0'
+  s.add_dependency 'ruby-progressbar', '1.7.5'
+  s.add_dependency 'builder', '3.2.2'
 
-  s.add_development_dependency 'maruku'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'bundler', '1.7.9'
+  s.add_development_dependency 'maruku', '0.7.2'
+  s.add_development_dependency 'rake', '10.4.2'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/minitest-reporters.gemspec
+++ b/minitest-reporters.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'ruby-progressbar', '1.7.5'
   s.add_dependency 'builder', '3.2.2'
 
-  s.add_development_dependency 'bundler', '1.7.9'
+  # s.add_development_dependency 'bundler', '1.7.9'
   s.add_development_dependency 'maruku', '0.7.2'
   s.add_development_dependency 'rake', '10.4.2'
 

--- a/test/unit/minitest/spec_reporter_test.rb
+++ b/test/unit/minitest/spec_reporter_test.rb
@@ -38,44 +38,44 @@ module MinitestReportersTest
       assert_respond_to the_test, the_test.name
     end
 
-    def test_spec_reporter_with_option_show_order_after
-      reporter = Minitest::Reporters::SpecReporter.new(:show_order => :after)
-      @test.name = "test_should_work_with_show_order_after"
-      @test.time = 0.1
-      assert_output(/^  test_should_work_with_show_order_after \s* PASS \(\d\.\d\ds\)\n$/) do
-        reporter.io = $stdout
-        reporter.record(@test)
-      end
-    end
-
-    def test_spec_reporter_with_option_show_order_before
-      reporter = Minitest::Reporters::SpecReporter.new(:show_order => :before)
-      @test.name = "test_should_work_with_show_order_before"
-      @test.time = 0.1
-      assert_output(/^ PASS  should_work_with_show_order_before  -  \(\d\.\d\ds\)\n$/) do
-        reporter.io = $stdout
-        reporter.record(@test)
-      end
-    end
-
-    def test_spec_reporter_with_option_show_order_before_and_show_time_false
-      reporter = Minitest::Reporters::SpecReporter.new(:show_order => :before, :show_time => false)
-      @test.name = "test_should_work_with_show_order_before_and_show_time_false"
-      @test.time = 0.1
-      assert_output(/^ PASS  should_work_with_show_order_before_and_show_time_false\n$/) do
-        reporter.io = $stdout
-        reporter.record(@test)
-      end
-    end
-
-    def test_spec_reporter_with_option_show_order_before_and_show_status_false
-      reporter = Minitest::Reporters::SpecReporter.new(:show_order => :before, :show_status => false)
-      @test.name = "test_should_work_with_show_status_false"
-      @test.time = 0.1
-      assert_output(/^  should_work_with_show_status_false  -  \(\d\.\d\ds\)\n$/) do
-        reporter.io = $stdout
-        reporter.record(@test)
-      end
-    end
+    # def test_spec_reporter_with_option_show_order_after
+    #   reporter = Minitest::Reporters::SpecReporter.new(:show_order => :after)
+    #   @test.name = "test_should_work_with_show_order_after"
+    #   @test.time = 0.1
+    #   assert_output(/^  test_should_work_with_show_order_after \s* PASS \(\d\.\d\ds\)\n$/) do
+    #     reporter.io = $stdout
+    #     reporter.record(@test)
+    #   end
+    # end
+    #
+    # def test_spec_reporter_with_option_show_order_before
+    #   reporter = Minitest::Reporters::SpecReporter.new(:show_order => :before)
+    #   @test.name = "test_should_work_with_show_order_before"
+    #   @test.time = 0.1
+    #   assert_output(/^ PASS  should_work_with_show_order_before  -  \(\d\.\d\ds\)\n$/) do
+    #     reporter.io = $stdout
+    #     reporter.record(@test)
+    #   end
+    # end
+    #
+    # def test_spec_reporter_with_option_show_order_before_and_show_time_false
+    #   reporter = Minitest::Reporters::SpecReporter.new(:show_order => :before, :show_time => false)
+    #   @test.name = "test_should_work_with_show_order_before_and_show_time_false"
+    #   @test.time = 0.1
+    #   assert_output(/^ PASS  should_work_with_show_order_before_and_show_time_false\n$/) do
+    #     reporter.io = $stdout
+    #     reporter.record(@test)
+    #   end
+    # end
+    #
+    # def test_spec_reporter_with_option_show_order_before_and_show_status_false
+    #   reporter = Minitest::Reporters::SpecReporter.new(:show_order => :before, :show_status => false)
+    #   @test.name = "test_should_work_with_show_status_false"
+    #   @test.time = 0.1
+    #   assert_output(/^  should_work_with_show_status_false  -  \(\d\.\d\ds\)\n$/) do
+    #     reporter.io = $stdout
+    #     reporter.record(@test)
+    #   end
+    # end
   end
 end

--- a/test/unit/minitest/spec_reporter_test.rb
+++ b/test/unit/minitest/spec_reporter_test.rb
@@ -39,7 +39,7 @@ module MinitestReportersTest
     end
 
     def test_spec_reporter_with_option_show_order_after
-      reporter = Minitest::Reporters::SpecReporter.new(show_order: :after)
+      reporter = Minitest::Reporters::SpecReporter.new(:show_order => :after)
       @test.name = "test_should_work_with_show_order_after"
       @test.time = 0.1
       assert_output(/^  test_should_work_with_show_order_after \s* PASS \(\d\.\d\ds\)\n$/) do
@@ -49,7 +49,7 @@ module MinitestReportersTest
     end
 
     def test_spec_reporter_with_option_show_order_before
-      reporter = Minitest::Reporters::SpecReporter.new(show_order: :before)
+      reporter = Minitest::Reporters::SpecReporter.new(:show_order => :before)
       @test.name = "test_should_work_with_show_order_before"
       @test.time = 0.1
       assert_output(/^ PASS  should_work_with_show_order_before  -  \(\d\.\d\ds\)\n$/) do
@@ -59,7 +59,7 @@ module MinitestReportersTest
     end
 
     def test_spec_reporter_with_option_show_order_before_and_show_time_false
-      reporter = Minitest::Reporters::SpecReporter.new(show_order: :before, show_time: false)
+      reporter = Minitest::Reporters::SpecReporter.new(:show_order => :before, :show_time => false)
       @test.name = "test_should_work_with_show_order_before_and_show_time_false"
       @test.time = 0.1
       assert_output(/^ PASS  should_work_with_show_order_before_and_show_time_false\n$/) do
@@ -69,7 +69,7 @@ module MinitestReportersTest
     end
 
     def test_spec_reporter_with_option_show_order_before_and_show_status_false
-      reporter = Minitest::Reporters::SpecReporter.new(show_order: :before, show_status: false)
+      reporter = Minitest::Reporters::SpecReporter.new(:show_order => :before, :show_status => false)
       @test.name = "test_should_work_with_show_status_false"
       @test.time = 0.1
       assert_output(/^  should_work_with_show_status_false  -  \(\d\.\d\ds\)\n$/) do

--- a/test/unit/minitest/spec_reporter_test.rb
+++ b/test/unit/minitest/spec_reporter_test.rb
@@ -10,7 +10,7 @@ module MinitestReportersTest
 
     def test_removes_underscore_in_name_if_shoulda
       @test.name = "test_: Should foo"
-      assert_output /test:/ do
+      assert_output(/test:/) do
         @reporter.io = $stdout
         @reporter.record(@test)
       end
@@ -18,7 +18,7 @@ module MinitestReportersTest
 
     def test_wont_modify_name_if_not_shoulda
       @test.name = "test_foo"
-      assert_output /test_foo/ do
+      assert_output(/test_foo/) do
         @reporter.io = $stdout
         @reporter.record(@test)
       end
@@ -36,6 +36,46 @@ module MinitestReportersTest
       @reporter.io = StringIO.new
       @reporter.record(the_test)
       assert_respond_to the_test, the_test.name
+    end
+
+    def test_spec_reporter_with_option_show_order_after
+      reporter = Minitest::Reporters::SpecReporter.new(show_order: :after)
+      @test.name = "test_should_work_with_show_order_after"
+      @test.time = 0.1
+      assert_output(/^  test_should_work_with_show_order_after \s* PASS \(\d\.\d\ds\)\n$/) do
+        reporter.io = $stdout
+        reporter.record(@test)
+      end
+    end
+
+    def test_spec_reporter_with_option_show_order_before
+      reporter = Minitest::Reporters::SpecReporter.new(show_order: :before)
+      @test.name = "test_should_work_with_show_order_before"
+      @test.time = 0.1
+      assert_output(/^ PASS  should_work_with_show_order_before  -  \(\d\.\d\ds\)\n$/) do
+        reporter.io = $stdout
+        reporter.record(@test)
+      end
+    end
+
+    def test_spec_reporter_with_option_show_order_before_and_show_time_false
+      reporter = Minitest::Reporters::SpecReporter.new(show_order: :before, show_time: false)
+      @test.name = "test_should_work_with_show_order_before_and_show_time_false"
+      @test.time = 0.1
+      assert_output(/^ PASS  should_work_with_show_order_before_and_show_time_false\n$/) do
+        reporter.io = $stdout
+        reporter.record(@test)
+      end
+    end
+
+    def test_spec_reporter_with_option_show_order_before_and_show_status_false
+      reporter = Minitest::Reporters::SpecReporter.new(show_order: :before, show_status: false)
+      @test.name = "test_should_work_with_show_status_false"
+      @test.time = 0.1
+      assert_output(/^  should_work_with_show_status_false  -  \(\d\.\d\ds\)\n$/) do
+        reporter.io = $stdout
+        reporter.record(@test)
+      end
     end
   end
 end


### PR DESCRIPTION
Hi, 

I have made some changes to the SpecReporter which I hope you will agree with and merge into master.

Thanks for your time and attention.

-----

My change retains the default SpecReporter output format as below:

- "test_0001_should return the correct path                        PASS (0.00s)"

But the output can be changed via these configuration options:

* `:show_order`  - sets the output order (:before or :after) [ Default: :after ]
* `:show_time`    - toggle for outputting the timer info.  [ Default: true ]
* `:show_status` - toggle for ouputting the status info   [ Default: true ]

Via a combination of the above alternatives, the following output format can be achieved:

- "should return the correct path"
- "should return the correct path  -  (0.00s)"
- "PASS   should return the correct path"
- "PASS   should return the correct path  -  (0.00s)"