### PR TITLE
Fixing issue with junit reporter attaching wrong test classname

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -48,7 +48,7 @@ module Minitest
                       :errors => suite_result[:error_count], :tests => suite_result[:test_count],
                       :assertions => suite_result[:assertion_count], :time => suite_result[:time]) do
           tests.each do |test|
-            xml.testcase(:name => test.name, :classname => suite, :assertions => test.assertions,
+            xml.testcase(:name => test.name, :classname => test.class, :assertions => test.assertions,
                          :time => test.time) do
               xml << xml_message_for(test) unless test.passed?
             end

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -17,7 +17,8 @@ module Minitest
 
       def initialize(options = {})
         super
-        @detailed_skip = options.fetch(:detailed_skip, true)
+        @detailed_skip  = options.fetch(:detailed_skip, true)
+        @slow_treshold  = options.fetch(:slow_treshold , nil)
 
         @progress = ProgressBar.create({
           total:          total_count,
@@ -70,6 +71,16 @@ module Minitest
         print(send(color) { '%d failures, %d errors, ' } % [failures, errors])
         print(yellow { '%d skips' } % skips)
         puts
+
+        if @slow_treshold
+          slow_tests = tests.select{|t| t.time > @slow_treshold.to_f}
+          puts
+          puts('%d slow tests:' % slow_tests.size)
+          puts
+          slow_tests.sort_by(&:time).reverse.each do |test|
+            puts("%.5fs\t #{test.class}##{test.name}" % test.time)
+          end
+        end
       end
 
       private

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -45,7 +45,7 @@ module Minitest
         if @slow_treshold && test.time > @slow_treshold.to_f
           print "\e[0m\e[1000D\e[K"
           time = yellow('%.5f' % test.time)
-          print("Slow Test: #{time}s #{test.class}##{test.name}")
+          print("Slow Test: #{time} 🐌\t#{test.class}##{test.name}")
           puts
         end
 

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -41,6 +41,14 @@ module Minitest
 
       def record(test)
         super
+
+        if @slow_treshold && test.time > @slow_treshold.to_f
+          print "\e[0m\e[1000D\e[K"
+          time = yellow('%.5f' % test.time)
+          print("Slow Test: #{time}s #{test.class}##{test.name}")
+          puts
+        end
+
         return if test.skipped? && !@detailed_skip
         if test.failure
           print "\e[0m\e[1000D\e[K"
@@ -71,16 +79,6 @@ module Minitest
         print(send(color) { '%d failures, %d errors, ' } % [failures, errors])
         print(yellow { '%d skips' } % skips)
         puts
-
-        if @slow_treshold
-          slow_tests = tests.select{|t| t.time > @slow_treshold.to_f}
-          puts
-          puts('%d slow tests:' % slow_tests.size)
-          puts
-          slow_tests.sort_by(&:time).reverse.each do |test|
-            puts("%.5fs\t #{test.class}##{test.name}" % test.time)
-          end
-        end
       end
 
       private


### PR DESCRIPTION
it should use classname of the test that ran, not the test runner class.
