### PR TITLE
Add HtmlReporter to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Minitest::Reporters::RubyMateReporter # => Simple reporter designed for RubyMate
 Minitest::Reporters::RubyMineReporter # => Reporter designed for RubyMine IDE and TeamCity CI server
 Minitest::Reporters::JUnitReporter    # => JUnit test reporter designed for JetBrains TeamCity
 Minitest::Reporters::MeanTimeReporter # => Produces a report summary showing the slowest running tests
+Minitest::Reporters::HtmlReporter     # => Generates an HTML report of the test results
 ```
 
 Options can be passed to these reporters at construction-time, e.g. to force


### PR DESCRIPTION
I stumbled onto the html reporter and noticed that it was not included in the readme, so now it is.