### PR TITLE
Splitting SpecReporter#report for enhanced extensibility

### DIFF
--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -28,15 +28,8 @@ module Minitest
 
       def record(test)
         super
-        test_name = test.name.gsub(/^test_: /, 'test:')
-        print pad_test(test_name)
-        print_colored_status(test)
-        print(" (%.2fs)" % test.time) unless test.time.nil?
-        puts
-        if !test.skipped? && test.failure
-          print_info(test.failure)
-          puts
-        end
+        record_print_status(test)
+        record_print_failures_if_any(test)
       end
 
       protected
@@ -47,6 +40,21 @@ module Minitest
 
       def after_suite(suite)
         puts
+      end
+
+      def record_print_status(test)
+        test_name = test.name.gsub(/^test_: /, 'test:')
+        print pad_test(test_name)
+        print_colored_status(test)
+        print(" (%.2fs)" % test.time) unless test.time.nil?
+        puts
+      end
+
+      def record_print_failures_if_any(test)
+        if !test.skipped? && test.failure
+          print_info(test.failure)
+          puts
+        end
       end
     end
   end


### PR DESCRIPTION
Dear Oleg @os97673,

I see you are one of Cucumber's biggest contributors. I think cucumber reports are awesome, but some people/companies don't like to use it for their own reasons. So I built a small gem called "bdd", which brings the benefits of cucumber-style Given/When/Then/And/But reports to non-cucumber users.

I recently started integrating with Minitest but I need to manually reopen SpecReporter so I can add a custom hook in the middle of the name and failure printings so the report will make more sense to the reader (example in the code of this PR)

Here is the output.

![image 2016-04-10 at 9 39 04 pm](https://cloud.githubusercontent.com/assets/335238/14414194/5ef10356-ff65-11e5-8710-67cc94fbf83f.png)

I don't know if you will like this approach.

Do you think splitting these two printings would help other developers in the future too?

Do you believe there is a better way to accomplish the same result?

Nonetheless, I hope this PR helps other people who want to extend from minitest-reporters,
I would be happy to adapt the code if you have any preferences.

Best,
James.