### PR TITLE
RubyMine reporter provides file URL. Jump to test fixed

### DIFF
--- a/lib/minitest/reporters/rubymine_reporter.rb
+++ b/lib/minitest/reporters/rubymine_reporter.rb
@@ -88,8 +88,8 @@ else
 
         def before_test(test)
           super
-          fqn = "#{test.class.name}.#{test.name}"
-          log(@message_factory.create_test_started(test.name, minitest_test_location(fqn)))
+          location = test.class.instance_method(test.name).source_location
+          log(@message_factory.create_test_started(test.name, "file://#{location[0]}:#{location[1]}"))
         end
 
         #########
@@ -100,11 +100,6 @@ else
 
           # returns:
           msg
-        end
-
-        def minitest_test_location(fqn)
-          return nil if (fqn.nil?)
-          "ruby_minitest_qn://#{fqn}"
         end
 
         def with_result(test)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/RUBY-16613  (minitest failure result nodes need "jump to test" functionality). rubymine-reporter provided only name of tested object and testing method's name. It was impossible to restore location of test method. Now reporter provides location. 