### PR TITLE
Move HtmlReporter deletion to #start

### DIFF
--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -73,6 +73,10 @@ module Minitest
         reports_dir = settings[:reports_dir]
 
         @reports_path = File.absolute_path(reports_dir)
+      end
+
+      def start
+        super
 
         puts "Emptying #{@reports_path}"
         FileUtils.mkdir_p(@reports_path)


### PR DESCRIPTION
- Moving the deletion of the HTML report from constructor to
  #start hook ensures that any existing HTML report doesn't
  get wiped when being used with RubyMine reporter.