### PR TITLE
Ensure DelegateReporter behaves on SIGINFO

### DIFF
--- a/lib/minitest/minitest_reporter_plugin.rb
+++ b/lib/minitest/minitest_reporter_plugin.rb
@@ -26,6 +26,8 @@ module Minitest
         all_reporters.each(&:report)
       end
 
+      alias to_s report
+
       def passed?
         all_reporters.all?(&:passed?)
       end

--- a/test/unit/minitest/minitest_reporter_plugin_test.rb
+++ b/test/unit/minitest/minitest_reporter_plugin_test.rb
@@ -10,5 +10,16 @@ module MinitestReportersTest
       dr.send :all_reporters
       assert_equal io_handle, reporter.io
     end
+
+    def test_casting_to_string_triggers_report
+      reporter  = Minitest::Reporters::ProgressReporter.new
+      io_handle = StringIO.new
+      dr = Minitest::Reporters::DelegateReporter.new([ reporter ], :io => io_handle)
+
+      dr.to_s
+
+      io_handle.rewind
+      assert_match(/\d+ tests, \d+ assertions/, io_handle.read)
+    end
   end
 end


### PR DESCRIPTION
This issue was addressed before, in PR #152.

However, since then, the `DelegateReporter` wrapper class was added in 25d19942 in response to issue #168.

This PR adds in a similar fix to #152 to ensure the desired behaviour continues to work.