### PR TITLE
Fix progress bar when using filter and specs

### DIFF
--- a/lib/minitest/minitest_reporter_plugin.rb
+++ b/lib/minitest/minitest_reporter_plugin.rb
@@ -36,9 +36,9 @@ module Minitest
         filter = options[:filter] || '/./'
         filter = Regexp.new $1 if filter =~ /\/(.*)\//
 
-        Minitest::Runnable.runnables.map(&:runnable_methods).flatten.find_all { |m|
-          filter === m || filter === "#{self}##{m}"
-        }.size
+        Minitest::Runnable.runnables.map { |runnable|
+          runnable.runnable_methods.map { |m| "#{runnable}##{m}" }
+        }.flatten.grep(filter).size
       end
 
       def all_reporters

--- a/lib/minitest/minitest_reporter_plugin.rb
+++ b/lib/minitest/minitest_reporter_plugin.rb
@@ -37,8 +37,10 @@ module Minitest
         filter = Regexp.new $1 if filter =~ /\/(.*)\//
 
         Minitest::Runnable.runnables.map { |runnable|
-          runnable.runnable_methods.map { |m| "#{runnable}##{m}" }
-        }.flatten.grep(filter).size
+          runnable.runnable_methods.find_all { |m|
+            filter === m || filter === "#{runnable}##{m}"
+          }.size
+        }.inject(:+)
       end
 
       def all_reporters

--- a/test/fixtures/spec_test.rb
+++ b/test/fixtures/spec_test.rb
@@ -1,0 +1,13 @@
+require 'minitest'
+require 'minitest/reporters'
+require 'minitest/autorun'
+
+Minitest::Reporters.use! Minitest::Reporters::ProgressReporter.new
+
+describe String do
+  describe '#length' do
+    it 'works' do
+      assert_equal 5, 'hello'.length
+    end
+  end
+end

--- a/test/integration/reporters/progress_reporter_test.rb
+++ b/test/integration/reporters/progress_reporter_test.rb
@@ -18,5 +18,11 @@ module MinitestReportersTest
       assert_match 'FAIL["test_failure"', output, 'Failures should be displayed'
       refute_match 'SKIP["test_skip', output, 'Skipped tests should not be displayed'
     end
+    def test_progress_works_with_filter_and_specs
+      fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
+      test_filename = File.join(fixtures_directory, 'spec_test.rb')
+      output = `ruby #{test_filename} -n /length/ 2>&1`
+      refute_match '0 out of 0', output, 'Progress should not puts a warning'
+    end
   end
 end

--- a/test/integration/reporters/progress_reporter_test.rb
+++ b/test/integration/reporters/progress_reporter_test.rb
@@ -24,5 +24,11 @@ module MinitestReportersTest
       output = `ruby #{test_filename} -n /length/ 2>&1`
       refute_match '0 out of 0', output, 'Progress should not puts a warning'
     end
+    def test_progress_works_with_strict_filter
+      fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
+      test_filename = File.join(fixtures_directory, 'spec_test.rb')
+      output = `ruby #{test_filename} -n /^test_0001_works$/ 2>&1`
+      refute_match '0 out of 0', output, 'Progress should not puts a warning'
+    end
   end
 end


### PR DESCRIPTION
* Make the correct calculation when filtering on minitest/spec and using the progress reporter

When running with `minitest/spec` style tests and using filtering on class part, the tests are correctly executed, but the progress bar reporter doesn't. The total count of tests is at 0, and the output is the following : 

```
  0/0: [===================================] 100% Time: 00:00:00, Time: 00:00:00
WARNING: Your progress bar is currently at 0 out of 0 and cannot be incremented. In v2.0.0 this will become a ProgressBar::InvalidProgressError.
  0/0: [===================================] 100% Time: 00:00:01, Time: 00:00:01
```

This patch ensures the right count is done and as such the output is correct.