### PR TITLE
Fix references to GitHub pull requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## [1.1.16](https://github.com/kern/minitest-reporters/compare/v1.1.15...v1.1.14)
 
-* reverted fix for [#231](#231) to fix[#233](#233)
+* reverted fix for [#231](https://github.com/kern/minitest-reporters/pull/231) to fix[#233](https://github.com/kern/minitest-reporters/pull/233)
 
 ## [1.1.15](https://github.com/kern/minitest-reporters/compare/v1.1.14...v1.1.15)
 
-* Fixed problem with handling SIGINFO [#231](#231) (contributed by [joshpencheon](https://github.com/joshpencheon))
+* Fixed problem with handling SIGINFO [#231](https://github.com/kern/minitest-reporters/pull/231) (contributed by [joshpencheon](https://github.com/joshpencheon))
 
 


### PR DESCRIPTION
GitHub's autolinked references doesn't work in markdown files and
we have to manually add the links.