### PR TITLE
Only use DelegateReporter if it's been explicitly asked for.

### DIFF
--- a/lib/minitest/minitest_reporter_plugin.rb
+++ b/lib/minitest/minitest_reporter_plugin.rb
@@ -69,6 +69,7 @@ module Minitest
 
   class << self
     def plugin_minitest_reporter_init(options)
+      return unless Minitest::Reporters.respond_to?(:reporters) && Minitest::Reporters.reporters
       reporter.reporters = [Minitest::Reporters::DelegateReporter.new(reporter.reporters, options)]
     end
   end


### PR DESCRIPTION
This will mean that the reporters are only overridden if `Minitest::Reporters.use!` has been called.

The `respond_to?` check is for cases where the plugin is on your GEM_PATH but you haven't actually required the gem.