### PR TITLE
Override Minitest.parallel_fork_stat_reporter if it's available

### DIFF
--- a/lib/minitest/minitest_reporter_plugin.rb
+++ b/lib/minitest/minitest_reporter_plugin.rb
@@ -70,6 +70,12 @@ module Minitest
   class << self
     def plugin_minitest_reporter_init(options)
       reporter.reporters = [Minitest::Reporters::DelegateReporter.new(reporter.reporters, options)]
+
+      return unless respond_to?(:parallel_fork_stat_reporter)
+      define_singleton_method :parallel_fork_stat_reporter do |reporter|
+        reporter.reporters.detect { |rep| rep.is_a?(Minitest::Reporters::DelegateReporter) }
+                .send(:all_reporters).detect { |rep| rep.is_a?(StatisticsReporter) }
+      end
     end
   end
 end


### PR DESCRIPTION
- Provides integration with minitest-parallel_fork > 1.0.2

/cc @jeremyevans