### PR TITLE
Use block syntax to close files after writing

### DIFF
--- a/lib/minitest/reporters/mean_time_reporter.rb
+++ b/lib/minitest/reporters/mean_time_reporter.rb
@@ -260,11 +260,15 @@ module Minitest
             previous_run.store("#{description}", new_times)
           end
 
-          File.write(previous_runs_filename, previous_run.to_yaml)
+          File.open(previous_runs_filename, 'w+') do |f|
+            f.write(previous_run.to_yaml)
+          end
 
         else
 
-          File.write(previous_runs_filename, current_run.to_yaml)
+          File.open(previous_runs_filename, 'w+') do |f|
+            f.write(current_run.to_yaml)
+          end
 
         end
       end
@@ -287,7 +291,9 @@ module Minitest
       #
       # @return [void]
       def create_new_report!
-        File.write(report_filename, report_title + report_body)
+        File.open(report_filename, 'w+') do |f|
+          f.write(report_title + report_body)
+        end
       end
 
       # Writes a number of tests (configured via the 'show_count' option) to the


### PR DESCRIPTION
I added minitest-reporters to two large Rails apps in order to use
the MeanTimeReporter to identify the slowest running tests.

I started seeing `Errno::EMFILE: Too many open files` errors. The errors
occur intermittently locally, but consistently on CI. I don't really
think that it's minitest-reporters "fault", however when reviewing the
code I noticed that there were a couple places in the reporter that file
handles could be being left open.

This PR switches to using the block syntax to open and then write to a
file (as is done elsewhere in the reporter), which implicitly closes the
file when exiting the block.