### PR TITLE
Make output in `single_file` mode use the proper suite, add `filepath` and `lineno` attribute

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -62,7 +62,8 @@ module Minitest
                       :errors => suite_result[:error_count], :tests => suite_result[:test_count],
                       :assertions => suite_result[:assertion_count], :time => suite_result[:time]) do
           tests.each do |test|
-            xml.testcase(:name => test.name, :classname => suite, :assertions => test.assertions,
+            lineno = test.method(test.name).source_location.last
+            xml.testcase(:name => test.name, :lineno => lineno, :classname => suite, :assertions => test.assertions,
                          :time => test.time) do
               xml << xml_message_for(test) unless test.passed?
             end

--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -13,6 +13,7 @@ module Minitest
         super({})
         @reports_path = File.absolute_path(reports_dir)
         @single_file = options[:single_file]
+        @base_path = options[:base_path] || Dir.pwd
 
         if empty
           puts "Emptying #{@reports_path}"
@@ -52,8 +53,12 @@ module Minitest
 
       def parse_xml_for(xml, suite, tests)
         suite_result = analyze_suite(tests)
+        file_path = Pathname.new(tests.first.method(tests.first.name).source_location.first)
+        base_path = Pathname.new(@base_path)
+        relative_path = file_path.relative_path_from(base_path)
 
-        xml.testsuite(:name => suite, :skipped => suite_result[:skip_count], :failures => suite_result[:fail_count],
+        xml.testsuite(:name => suite, :filepath => relative_path,
+                      :skipped => suite_result[:skip_count], :failures => suite_result[:fail_count],
                       :errors => suite_result[:error_count], :tests => suite_result[:test_count],
                       :assertions => suite_result[:assertion_count], :time => suite_result[:time]) do
           tests.each do |test|


### PR DESCRIPTION
The problem
---
- single file mode prints out many suites in a single suite, but labels them all as "minitest"
- filepath/lineno, despite not being in spec, can be useful for ruby programs (and are standard in minitest/rails, for example) to find a test file to use in tests
- same with line number for a test

The changes
---
- single_file mode now prints a single file with a nested `testsuites` option (as per spec). The suite entries now all use the proper `suite` (see last point for example)
- filepath is calculated from the current directory (or the directory that you define with `:base_path`) and the filepath is added to the `testsuite` entry
- adds `lineno` to the `test` entry
- refactors slightly to adhere to [junit spec format](https://www.ibm.com/support/knowledgecenter/en/SSQ2R2_14.0.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html):

```xml
<testsuites>
  <testsuite suite="A"></testsuite>
  <testsuite suite="B"></testsuite>
</testsuites>
```