### PR TITLE
Check for nil value in before_test and modified check for calling after_suite in before_test

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -1,4 +1,3 @@
-require 'pp'
 module Minitest
   module Reporters
     class BaseReporter < Minitest::StatisticsReporter
@@ -15,7 +14,7 @@ module Minitest
 
       # called by our own before hooks
       def before_test(test)
-      	last_test = tests.last
+        last_test = tests.last
         before_suite(test.class) if last_test.nil?
         after_suite(last_test.class) if last_test == 'Minitest::Result'
       end

--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -1,3 +1,4 @@
+require 'pp'
 module Minitest
   module Reporters
     class BaseReporter < Minitest::StatisticsReporter
@@ -14,11 +15,9 @@ module Minitest
 
       # called by our own before hooks
       def before_test(test)
-        last_test = tests.last
-        if last_test.class != test.class
-          after_suite(last_test.class) if last_test
-          before_suite(test.class)
-        end
+      	last_test = tests.last
+        before_suite(test.class) if last_test.nil?
+        after_suite(last_test.class) if last_test == 'Minitest::Result'
       end
 
       def record(test)

--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -15,8 +15,11 @@ module Minitest
       # called by our own before hooks
       def before_test(test)
         last_test = tests.last
-        before_suite(test.class) if last_test.nil?
-        after_suite(last_test.class) if last_test == 'Minitest::Result'
+        if last_test.nil?
+          before_suite(test.class)
+        elsif is_a?(last_test.class) == String
+          after_suite(last_test.class)
+        end
       end
 
       def record(test)


### PR DESCRIPTION
In response to #248 in the file `lib/minitest/reporters/base_reporter.rb` after the check for the nil the code was in place `after_suite` was still repetitively called and by adding the text check for `'Minitest::Result'` this will now call `after_suite` at the appropriate time. I tested on Minitest 5.11.1 using the SpecReporter, RubyMineReporter, DefaultReporter, and a custom reporter I am using. I followed that up by testing back on 5.10.3 to verify that it works on the older version as well.