### PR TITLE
Adding test for response to klass on MiniTest::Result object

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -1,4 +1,3 @@
-require 'pp'
 module Minitest
   module Reporters
     class BaseReporter < Minitest::StatisticsReporter

--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -1,3 +1,4 @@
+require 'pp'
 module Minitest
   module Reporters
     class BaseReporter < Minitest::StatisticsReporter
@@ -15,7 +16,15 @@ module Minitest
       # called by our own before hooks
       def before_test(test)
         last_test = tests.last
-        if last_test.class != test.class
+
+				# Minitest broke API between 5.10 and 5.11 this gets around Result object
+        if last_test.respond_to? :klass
+          suite_changed = last_test.klass != test.class.name
+				else
+          suite_changed = last_test.class != test.class
+        end
+
+        if suite_changed
           after_suite(last_test.class) if last_test
           before_suite(test.class)
         end


### PR DESCRIPTION
This is in reference to https://github.com/kern/minitest-reporters/pull/249 the people in the https://github.com/seattlerb/minitest project made an API change with version 5.11.3+ on the commit https://github.com/seattlerb/minitest/commit/00433fc0a4fdd0e6b302aace633384ba13122376#diff-444fa8babd8886c012733b064d709db5 where they added the object Result. The solution I am proposing with collaboration from @aarontc is that a check performed on `last_test` to respond to the variable `klass` of which is where minitest now stores the class name of the test class. After this check is performed a not equal is checked in both places of the if else statement to validate the start of a new suite. I intend to log an issue with the people at minitest around the API level change for a minor version.