### PR TITLE
Adapt JUnitReporter for minitest >= 5.11

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -26,7 +26,10 @@ module Minitest
         super
 
         puts "Writing XML reports to #{@reports_path}"
-        suites = tests.group_by(&:class)
+        suites = tests.group_by { |test|
+          return test.klass if test.respond_to? :klass
+          test.class
+        }
 
         if @single_file
           xml = Builder::XmlMarkup.new(:indent => 2)

--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -27,8 +27,11 @@ module Minitest
 
         puts "Writing XML reports to #{@reports_path}"
         suites = tests.group_by { |test|
-          return test.klass if test.respond_to? :klass
-          test.class
+          if test.respond_to? :klass
+            test.klass
+          else
+            test.class
+          end
         }
 
         if @single_file


### PR DESCRIPTION
Minitest 5.11.0 change the format of `test` passed to `record`.
`test.class` return `Minitest::Result`, we have to call `test.klass`.

The issue is that JUnit parser will think that it's the same test if the `name` and `classname` is the same.