### PR TITLE
Allow force of specified reporter when calling use!

### DIFF
--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -36,7 +36,7 @@ module Minitest
       end
     end
 
-    def self.use_runner!(console_reporters, env, force = false)
+    def self.use_runner!(console_reporters, env, force)
       self.reporters = choose_reporters(console_reporters, env, force)
     end
 
@@ -58,7 +58,7 @@ module Minitest
       end
     end
 
-    def self.choose_reporters(console_reporters, env, force = false)
+    def self.choose_reporters(console_reporters, env, force)
       if env["TM_PID"] && !force
         [RubyMateReporter.new]
       elsif (env["RM_INFO"] || env["TEAMCITY_VERSION"]) && !force

--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -22,7 +22,7 @@ module Minitest
       attr_accessor :reporters
     end
 
-    def self.use!(console_reporters = ProgressReporter.new, env = ENV, backtrace_filter = nil)
+    def self.use!(console_reporters = ProgressReporter.new, env = ENV, backtrace_filter = nil, force = false)
       use_runner!(console_reporters, env)
       if backtrace_filter.nil? && !defined?(::Rails)
         backtrace_filter = ExtensibleBacktraceFilter.default_filter
@@ -36,7 +36,7 @@ module Minitest
       end
     end
 
-    def self.use_runner!(console_reporters, env)
+    def self.use_runner!(console_reporters, env, force = false)
       self.reporters = choose_reporters(console_reporters, env)
     end
 
@@ -58,12 +58,12 @@ module Minitest
       end
     end
 
-    def self.choose_reporters(console_reporters, env)
-      if env["TM_PID"]
+    def self.choose_reporters(console_reporters, env, force = false)
+      if env["TM_PID"] && !force
         [RubyMateReporter.new]
-      elsif env["RM_INFO"] || env["TEAMCITY_VERSION"]
+      elsif (env["RM_INFO"] || env["TEAMCITY_VERSION"]) && !force
         [RubyMineReporter.new]
-      elsif !env["VIM"]
+      elsif !env["VIM"] || force
         Array(console_reporters)
       end
     end

--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -23,7 +23,7 @@ module Minitest
     end
 
     def self.use!(console_reporters = ProgressReporter.new, env = ENV, backtrace_filter = nil, force = false)
-      use_runner!(console_reporters, env)
+      use_runner!(console_reporters, env, force)
       if backtrace_filter.nil? && !defined?(::Rails)
         backtrace_filter = ExtensibleBacktraceFilter.default_filter
       end
@@ -37,7 +37,7 @@ module Minitest
     end
 
     def self.use_runner!(console_reporters, env, force = false)
-      self.reporters = choose_reporters(console_reporters, env)
+      self.reporters = choose_reporters(console_reporters, env, force)
     end
 
     def self.use_around_test_hooks!

--- a/test/unit/minitest/reporters_test.rb
+++ b/test/unit/minitest/reporters_test.rb
@@ -15,6 +15,22 @@ module MinitestReportersTest
       end
     end
 
+    def test_chooses_given_reporter_when_forced
+      # Rubymine reporter complains when RubyMine libs are not available, so
+      # stub its #puts method out.
+      $stdout.stub :puts, nil do
+        given_reporter = Minitest::Reporters::JUnitReporter
+        reporters = Minitest::Reporters.choose_reporters [given_reporter.new], { "RM_INFO" => "x" }, true
+        assert_instance_of given_reporter, reporters[0]
+
+        reporters = Minitest::Reporters.choose_reporters [given_reporter.new], { "TEAMCITY_VERSION" => "x" }, true
+        assert_instance_of given_reporter, reporters[0]
+
+        reporters = Minitest::Reporters.choose_reporters [given_reporter.new], {"TM_PID" => "x"}, true
+        assert_instance_of given_reporter, reporters[0]
+      end
+    end
+
     def test_chooses_the_textmate_reporter_when_necessary
       reporters = Minitest::Reporters.choose_reporters [], {"TM_PID" => "x"}
       assert_instance_of Minitest::Reporters::RubyMateReporter, reporters[0]


### PR DESCRIPTION
- Allows force of a given reporter regardless of whether runner thinks it's in TeamCity, TextMate or VIM
- My particular problem was wanting to generate JUnit style reports in TeamCity so I can use a command line build step to run tests. This avoids a lot of issues with rvm and the limitations of TeamCity's Rake Runner, but allows me to still collect test results in the Test Results tab of TeamCity
- Had to dig into code to find that it ignores my requested Reporter if it 'detects' TeamCity
- This small change allows me to force it to honor my Reporter request.