### PR TITLE
Add MINITEST_REPORTER env variable to override ENV detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Detection of those systems is based on presence of certain ENV variables and are
 
 ```
  MINITEST_REPORTER => use reporter indicated in env variable
- TM_PID => RubyMateReporter
- RM_INFO => RubyMineReporter
- TEAMCITY_VERSION => RubyMineReporter
- VIM => Reporters disabled
+ TM_PID => use RubyMateReporter
+ RM_INFO => use RubyMineReporter
+ TEAMCITY_VERSION => use RubyMineReporter
+ VIM => disable all Reporters
 ```
 
 The following reporters are provided:

--- a/README.md
+++ b/README.md
@@ -47,16 +47,13 @@ export MINITEST_REPORTER=JUnitReporter
 
 Detection of those systems is based on presence of certain ENV variables and are evaulated in the following order:
 
-> MINITEST_REPORTER => use reporter indicated in env variable
-
-> TM_PID => RubyMateReporter
-
-> RM_INFO => RubyMineReporter
-
-> TEAMCITY_VERSION => RubyMineReporter
-
-> VIM => Reporters disabled
-
+```
+ MINITEST_REPORTER => use reporter indicated in env variable
+ TM_PID => RubyMateReporter
+ RM_INFO => RubyMineReporter
+ TEAMCITY_VERSION => RubyMineReporter
+ VIM => Reporters disabled
+```
 
 The following reporters are provided:
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,16 @@ export MINITEST_REPORTER=JUnitReporter
 
 Detection of those systems is based on presence of certain ENV variables and are evaulated in the following order:
 
-MINITEST_REPORTER => use reporter indicated in env variable
-TM_PID => RubyMateReporter
-RM_INFO => RubyMineReporter
-TEAMCITY_VERSION => RubyMineReporter
-VIM => Reporters disabled
+> MINITEST_REPORTER => use reporter indicated in env variable
+
+> TM_PID => RubyMateReporter
+
+> RM_INFO => RubyMineReporter
+
+> TEAMCITY_VERSION => RubyMineReporter
+
+> VIM => Reporters disabled
+
 
 The following reporters are provided:
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,17 @@ Want to use multiple reporters?
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::JUnitReporter.new]
 ```
 
-If RubyMate, TeamCity, RubMine or VIM presence us detected, reporter is automatically chosen. 
+If RubyMate, TeamCity, RubyMine or VIM presence is detected, the reporter will be automatically chosen,
+regardless of any reporters passed to the `use!` method.
+
 To override this behavior, you may set the ENV variable MINITEST_REPORTER:
 
 ```sh
 export MINITEST_REPORTER=JUnitReporter
 ```
 
-Overall ENV detection is based on presence of certain ENV variables and are evaulated in the following order:
+Detection of those systems is based on presence of certain ENV variables and are evaulated in the following order:
+
 MINITEST_REPORTER => use reporter indicated in env variable
 TM_PID => RubyMateReporter
 RM_INFO => RubyMineReporter

--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ Want to use multiple reporters?
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::JUnitReporter.new]
 ```
 
+If RubyMate, TeamCity, RubMine or VIM presence us detected, reporter is automatically chosen. 
+To override this behavior, you may set the ENV variable MINITEST_REPORTER:
+
+```sh
+export MINITEST_REPORTER=JUnitReporter
+```
+
+Overall ENV detection is based on presence of certain ENV variables and are evaulated in the following order:
+MINITEST_REPORTER => use reporter indicated in env variable
+TM_PID => RubyMateReporter
+RM_INFO => RubyMineReporter
+TEAMCITY_VERSION => RubyMineReporter
+VIM => Reporters disabled
+
 The following reporters are provided:
 
 ```ruby

--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -59,7 +59,9 @@ module Minitest
     end
 
     def self.choose_reporters(console_reporters, env)
-      if env["TM_PID"]
+      if env["MINITEST_REPORTER"]
+        [Minitest::Reporters.const_get(env["MINITEST_REPORTER"]).new]
+      elsif env["TM_PID"]
         [RubyMateReporter.new]
       elsif env["RM_INFO"] || env["TEAMCITY_VERSION"]
         [RubyMineReporter.new]

--- a/test/unit/minitest/reporters_test.rb
+++ b/test/unit/minitest/reporters_test.rb
@@ -31,6 +31,16 @@ module MinitestReportersTest
       assert_nil reporters
     end
 
+    def test_chooses_given_reporter_when_MINITEST_REPORTERS_env_set
+      env = {
+        "MINITEST_REPORTER" => "JUnitReporter", 
+        "RM_INFO" => "x", 
+        "TEAMCITY_VERSION" => "x", 
+        "TM_PID" => "x" }
+      reporters = Minitest::Reporters.choose_reporters [], env
+      assert_instance_of Minitest::Reporters::JUnitReporter, reporters[0]
+    end
+
     def test_uses_minitest_clock_time_when_minitest_version_greater_than_561
       Minitest::Reporters.stub :minitest_version, 583 do
         Minitest.stub :clock_time, 6765.378751009 do

--- a/test/unit/minitest/reporters_test.rb
+++ b/test/unit/minitest/reporters_test.rb
@@ -37,8 +37,11 @@ module MinitestReportersTest
         "RM_INFO" => "x", 
         "TEAMCITY_VERSION" => "x", 
         "TM_PID" => "x" }
-      reporters = Minitest::Reporters.choose_reporters [], env
-      assert_instance_of Minitest::Reporters::JUnitReporter, reporters[0]
+      # JUnit reporter init has stdout messages... capture them to keep test output clean
+      $stdout.stub :puts, nil do
+        reporters = Minitest::Reporters.choose_reporters [], env
+        assert_instance_of Minitest::Reporters::JUnitReporter, reporters[0]
+      end
     end
 
     def test_uses_minitest_clock_time_when_minitest_version_greater_than_561


### PR DESCRIPTION
- RubyMate, RubyMine, and TeamCity ENV detection overrides any specific reporter passed to `use!` method.
- Add a MINITEST_REPORTER env detection so users can override this detection and force usage of a specific reporter.
- Specific use case was attempting to use XML/JUnit style reports on TeamCity because of limitations of built-in Rake Runner step.
  - Rake Runner Build Step in TeamCity does a very poor job of choosing ruby versions automatically. Using a command-line runner for tests allows rvm to work as intended, and JUnit Reporter test output can be captured by TeamCity's XML Report Processing Build Feature.