### PR TITLE
Fix/time reporters

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -15,16 +15,10 @@ module Minitest
       # called by our own before hooks
       def before_test(test)
         last_test = tests.last
-
-        # Minitest broke API between 5.10 and 5.11 this gets around Result object
-        if last_test.respond_to? :klass
-          suite_changed = last_test.klass != test.class.name
-        else
-          suite_changed = last_test.class != test.class
-        end
+        suite_changed = test_class(last_test) != test.class
 
         if suite_changed
-          after_suite(last_test.class) if last_test
+          after_suite(test_class(last_test)) if last_test
           before_suite(test.class)
         end
       end
@@ -64,8 +58,8 @@ module Minitest
       end
 
       def test_class(result)
-        if result.respond_to? :klass
-          result.klass
+        if result.respond_to?(:klass) && result.klass
+          Object.const_get(result.klass)
         else
           result.class
         end

--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -59,7 +59,7 @@ module Minitest
 
       def test_class(result)
         if result.respond_to?(:klass) && result.klass
-          Object.const_get(result.klass)
+          load_constant(result.klass)
         else
           result.class
         end
@@ -104,6 +104,14 @@ module Minitest
         unless e.is_a?(MiniTest::UnexpectedError)
           trace = filter_backtrace(e.backtrace)
           trace.each { |line| print_with_info_padding(line) }
+        end
+      end
+
+      # This method is to be version compatible with ruby 1.X. In these
+      # versions constant lookup was not namespace aware
+      def load_constant(name)
+        name.to_s.split('::').inject(Object) do |namespace, const_name|
+          namespace.const_get(const_name)
         end
       end
     end

--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -34,7 +34,7 @@ module Minitest
 
       def report
         super
-        after_suite(tests.last.class)
+        after_suite(test_class(tests.last))
       end
 
       protected

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -125,7 +125,7 @@ module Minitest
           puts
 
           slow_suites.each do |slow_suite|
-            puts "%.6fs %s" % [slow_suite[1], test_class(slow_suite[0])]
+            puts "%.6fs %s" % [slow_suite[1], slow_suite[0]]
           end
         end
 


### PR DESCRIPTION
### Problem
The time based reporters stopped reporting correctly when `Minitest::Result` was introduced.

### Fix
Parse the Test and MiniTest::Result test class using the #test_class helper method.

### Tested On
Ruby 1.9.3
Ruby 2.3.1 
Ruby 2.5.1

### Steps to reproduce
https://gist.github.com/brendandeere/f8b9788f9d273298adbf64ddf79d758b

### Before:

<img width="727" alt="screen shot 2018-06-12 at 7 50 51 pm" src="https://user-images.githubusercontent.com/6353433/41323018-141874fa-6e7a-11e8-953b-db90a27e8498.png">

### After
<img width="750" alt="screen shot 2018-06-12 at 7 51 24 pm" src="https://user-images.githubusercontent.com/6353433/41323049-3af89a64-6e7a-11e8-8ad2-15000345d506.png">
