### PR TITLE
Fix mean time reporter, broken since 1.3.2

### DIFF
--- a/lib/minitest/reporters/mean_time_reporter.rb
+++ b/lib/minitest/reporters/mean_time_reporter.rb
@@ -124,8 +124,8 @@ module Minitest
           show_progress:          true,
           show_all_runs:          true,
           sort_column:            :avg,
-          previous_runs_filename: Dir.tmpdir + '/minitest_reporters_previous_run',
-          report_filename:        Dir.tmpdir + 'minitest_reporters_report',
+          previous_runs_filename: File.join(Dir.tmpdir, 'minitest_reporters_previous_run'),
+          report_filename:        File.join(Dir.tmpdir, 'minitest_reporters_report')
         }
       end
 

--- a/test/unit/minitest/mean_time_reporter_unit_test.rb
+++ b/test/unit/minitest/mean_time_reporter_unit_test.rb
@@ -20,6 +20,14 @@ module MinitestReportersTest
       File.delete(@report_file_path) if File.exist?(@report_file_path)
     end
 
+    def test_defaults
+      subject = Minitest::Reporters::MeanTimeReporter.new.send(:defaults)
+
+      expected_prefix = "#{Dir.tmpdir}#{File::Separator}"
+      assert_match expected_prefix, subject[:previous_runs_filename]
+      assert_match expected_prefix, subject[:report_filename]
+    end
+
     def test_sorts_avg_numerically
       prev_output = generate_report(:avg, :prev_time)
       report_output = generate_report(:avg, :cur_time)


### PR DESCRIPTION
I believe a small bug was introduced in 271141c2aaf26ed60db42e9daf57a88dcf35ac66, which seems to be fixed with this patch.

I did not run the test on Windows.