### PR TITLE
Fix duck check in JUnitReporter#get_source_location

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -62,7 +62,7 @@ module Minitest
       private
 
       def get_source_location(result)
-        if result.respond_to? :klass
+        if result.respond_to? :source_location
           result.source_location
         else
           result.method(result.name).source_location


### PR DESCRIPTION
Previously the method checks for :klass for some reason I couldn't quite figure out. This conflicts with one of our test code that has a

```rb
  let(:klass) { Some::Thing }
```

defined and this `:klass` caused the check to use the wrong branch of the `#get_source_location` method causing our Jenkins build to fail to produce test reports.

Looking at the code I'm not sure what's the relation between `:source_location` and `:klass`, I think the correct duck-checking code is to just check for method that's going to be used thus this PR.

If this is the wrong fix, please let me know or point me in the right direction. We have a large rails app and wading through our entire test stack is anything but fun.