### PR TITLE
Fix MeanTimeReporter#reset_statistics!, add specs and cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,6 +53,7 @@ task :gallery do
   end
 end
 
+desc 'Reset mean-time reporter statistics'
 task :reset_statistics do
   require 'minitest/reporters/mean_time_reporter'
   Minitest::Reporters::MeanTimeReporter.reset_statistics!

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 require 'rubocop/rake_task'
 
-task :default => :test
+task :default => [:test, :rubocop]
 Rake::TestTask.new do |t|
   t.pattern = "test/{unit,integration}/**/*_test.rb"
   t.verbose = true

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 require 'rubocop/rake_task'
 
-task :default => [:test, :rubocop]
+task :default => :test
 Rake::TestTask.new do |t|
   t.pattern = "test/{unit,integration}/**/*_test.rb"
   t.verbose = true

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,8 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 require 'rubocop/rake_task'
 
-task :default => :test
+task :default => [:test, :rubocop]
+
 Rake::TestTask.new do |t|
   t.pattern = "test/{unit,integration}/**/*_test.rb"
   t.verbose = true

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,7 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 require 'rubocop/rake_task'
 
-task :default => [:test, :rubocop]
-
+task :default => :test
 Rake::TestTask.new do |t|
   t.pattern = "test/{unit,integration}/**/*_test.rb"
   t.verbose = true

--- a/lib/minitest/extensible_backtrace_filter.rb
+++ b/lib/minitest/extensible_backtrace_filter.rb
@@ -9,8 +9,8 @@ module Minitest
     # @return [Minitest::ExtensibleBacktraceFilter]
     def self.default_filter
       unless defined? @default_filter
-        filter = new
-        filter.add_filter(%r{lib/minitest})
+        filter = self.new
+        filter.add_filter(/lib\/minitest/)
         @default_filter = filter
       end
 
@@ -55,7 +55,6 @@ module Minitest
 
       backtrace.each do |line|
         break if filters?(line)
-
         result << line
       end
 

--- a/lib/minitest/extensible_backtrace_filter.rb
+++ b/lib/minitest/extensible_backtrace_filter.rb
@@ -9,8 +9,8 @@ module Minitest
     # @return [Minitest::ExtensibleBacktraceFilter]
     def self.default_filter
       unless defined? @default_filter
-        filter = self.new
-        filter.add_filter(/lib\/minitest/)
+        filter = new
+        filter.add_filter(%r{lib/minitest})
         @default_filter = filter
       end
 
@@ -55,6 +55,7 @@ module Minitest
 
       backtrace.each do |line|
         break if filters?(line)
+
         result << line
       end
 

--- a/lib/minitest/minitest_reporter_plugin.rb
+++ b/lib/minitest/minitest_reporter_plugin.rb
@@ -35,15 +35,13 @@ module Minitest
       # stolen from minitest self.run
       def total_count(options)
         filter = options[:filter] || '/./'
-        filter = Regexp.new Regexp.last_match(1) if filter =~ %r{/(.*)/}
+        filter = Regexp.new $1 if filter =~ /\/(.*)\//
 
-        # rubocop:disable Style/BlockDelimiters
         Minitest::Runnable.runnables.map { |runnable|
           runnable.runnable_methods.find_all { |m|
-            m =~ filter || "#{runnable}##{m}" =~ filter
+            filter === m || filter === "#{runnable}##{m}"
           }.size
         }.inject(:+)
-        # rubocop:enable Style/BlockDelimiters
       end
 
       def all_reporters
@@ -52,7 +50,6 @@ module Minitest
 
       def init_all_reporters
         return @reporters unless defined?(Minitest::Reporters.reporters) && Minitest::Reporters.reporters
-
         (Minitest::Reporters.reporters + guard_reporter(@reporters)).each do |reporter|
           reporter.io = @options[:io]
           if reporter.respond_to?(:add_defaults)

--- a/lib/minitest/minitest_reporter_plugin.rb
+++ b/lib/minitest/minitest_reporter_plugin.rb
@@ -35,13 +35,15 @@ module Minitest
       # stolen from minitest self.run
       def total_count(options)
         filter = options[:filter] || '/./'
-        filter = Regexp.new $1 if filter =~ /\/(.*)\//
+        filter = Regexp.new Regexp.last_match(1) if filter =~ %r{/(.*)/}
 
+        # rubocop:disable Style/BlockDelimiters
         Minitest::Runnable.runnables.map { |runnable|
           runnable.runnable_methods.find_all { |m|
-            filter === m || filter === "#{runnable}##{m}"
+            m =~ filter || "#{runnable}##{m}" =~ filter
           }.size
         }.inject(:+)
+        # rubocop:enable Style/BlockDelimiters
       end
 
       def all_reporters
@@ -50,6 +52,7 @@ module Minitest
 
       def init_all_reporters
         return @reporters unless defined?(Minitest::Reporters.reporters) && Minitest::Reporters.reporters
+
         (Minitest::Reporters.reporters + guard_reporter(@reporters)).each do |reporter|
           reporter.io = @options[:io]
           if reporter.respond_to?(:add_defaults)

--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -29,11 +29,11 @@ module Minitest
       end
       Minitest.backtrace_filter = backtrace_filter unless backtrace_filter.nil?
 
-      unless defined?(@@loaded)
-        use_around_test_hooks!
-        use_old_activesupport_fix!
-        @@loaded = true
-      end
+      return true if defined?(@@loaded)
+
+      use_around_test_hooks!
+      use_old_activesupport_fix!
+      @@loaded = true
     end
 
     def self.use_runner!(console_reporters, env)
@@ -83,9 +83,9 @@ module Minitest
     end
 
     def self.use_old_activesupport_fix!
-      if defined?(ActiveSupport::VERSION) && ActiveSupport::VERSION::MAJOR < 4
-        require "minitest/old_activesupport_fix"
-      end
+      return unless defined?(ActiveSupport::VERSION) && ActiveSupport::VERSION::MAJOR < 4
+
+      require "minitest/old_activesupport_fix"
     end
   end
 end

--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -29,11 +29,11 @@ module Minitest
       end
       Minitest.backtrace_filter = backtrace_filter unless backtrace_filter.nil?
 
-      return true if defined?(@@loaded)
-
-      use_around_test_hooks!
-      use_old_activesupport_fix!
-      @@loaded = true
+      unless defined?(@@loaded)
+        use_around_test_hooks!
+        use_old_activesupport_fix!
+        @@loaded = true
+      end
     end
 
     def self.use_runner!(console_reporters, env)
@@ -83,9 +83,9 @@ module Minitest
     end
 
     def self.use_old_activesupport_fix!
-      return unless defined?(ActiveSupport::VERSION) && ActiveSupport::VERSION::MAJOR < 4
-
-      require "minitest/old_activesupport_fix"
+      if defined?(ActiveSupport::VERSION) && ActiveSupport::VERSION::MAJOR < 4
+        require "minitest/old_activesupport_fix"
+      end
     end
   end
 end

--- a/lib/minitest/reporters/ansi.rb
+++ b/lib/minitest/reporters/ansi.rb
@@ -4,6 +4,7 @@ module Minitest
       module Code
         def self.color?
           return false if ENV['MINITEST_REPORTERS_MONO']
+
           color_terminal = ENV['TERM'].to_s.downcase.include?("color")
           $stdout.tty? || color_terminal
         end

--- a/lib/minitest/reporters/ansi.rb
+++ b/lib/minitest/reporters/ansi.rb
@@ -4,7 +4,6 @@ module Minitest
       module Code
         def self.color?
           return false if ENV['MINITEST_REPORTERS_MONO']
-
           color_terminal = ENV['TERM'].to_s.downcase.include?("color")
           $stdout.tty? || color_terminal
         end

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -56,24 +56,20 @@ module Minitest
       end
 
       def on_record(test)
-        print "#{'%.2f' % test.time} = " if options[:verbose]
+        print "#{"%.2f" % test.time} = " if options[:verbose]
 
-        # Print the pass/skip/fail mark.
-        print result_from_test(test)
-
-        # Print fast_fail information
-        return unless @fast_fail && (test.skipped? || test.failure)
-
-        print_failure(test)
-      end
-
-      def result_from_test(test)
-        if test.passed?
+        # Print the pass/skip/fail mark
+        print(if test.passed?
           record_pass(test)
         elsif test.skipped?
           record_skip(test)
         elsif test.failure
           record_failure(test)
+        end)
+
+        # Print fast_fail information
+        if @fast_fail && (test.skipped? || test.failure)
+          print_failure(test)
         end
       end
 
@@ -142,17 +138,16 @@ module Minitest
 
       def print_failure(test)
         message = message_for(test)
-        return if message.nil? || message.strip.empty?
-
-        puts
-        puts colored_for(result(test), message)
+        unless message.nil? || message.strip == ''
+          puts
+          puts colored_for(result(test), message)
+        end
       end
 
       private
 
       def color?
         return @color if defined?(@color)
-
         @color = @options.fetch(:color) do
           io.tty? && (
             ENV["TERM"] =~ /^screen|color/ ||
@@ -175,16 +170,17 @@ module Minitest
 
       def colored_for(result, string)
         case result
-        when :fail, :error then red(string)
-        when :skip then yellow(string)
+        when :fail, :error; red(string)
+        when :skip; yellow(string)
         else green(string)
         end
       end
 
       def suite_result
-        if failures.nonzero? then :fail
-        elsif errors.nonzero? then :error
-        elsif skips.nonzero? then :skip
+        case
+        when failures > 0; :fail
+        when errors > 0; :error
+        when skips > 0; :skip
         else :pass
         end
       end
@@ -194,7 +190,6 @@ module Minitest
 
         exception.backtrace.reverse_each do |s|
           break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
-
           last_before_assertion = s
         end
 

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -56,20 +56,24 @@ module Minitest
       end
 
       def on_record(test)
-        print "#{"%.2f" % test.time} = " if options[:verbose]
+        print "#{'%.2f' % test.time} = " if options[:verbose]
 
-        # Print the pass/skip/fail mark
-        print(if test.passed?
+        # Print the pass/skip/fail mark.
+        print result_from_test(test)
+
+        # Print fast_fail information
+        return unless @fast_fail && (test.skipped? || test.failure)
+
+        print_failure(test)
+      end
+
+      def result_from_test(test)
+        if test.passed?
           record_pass(test)
         elsif test.skipped?
           record_skip(test)
         elsif test.failure
           record_failure(test)
-        end)
-
-        # Print fast_fail information
-        if @fast_fail && (test.skipped? || test.failure)
-          print_failure(test)
         end
       end
 
@@ -138,16 +142,17 @@ module Minitest
 
       def print_failure(test)
         message = message_for(test)
-        unless message.nil? || message.strip == ''
-          puts
-          puts colored_for(result(test), message)
-        end
+        return if message.nil? || message.strip.empty?
+
+        puts
+        puts colored_for(result(test), message)
       end
 
       private
 
       def color?
         return @color if defined?(@color)
+
         @color = @options.fetch(:color) do
           io.tty? && (
             ENV["TERM"] =~ /^screen|color/ ||
@@ -170,17 +175,16 @@ module Minitest
 
       def colored_for(result, string)
         case result
-        when :fail, :error; red(string)
-        when :skip; yellow(string)
+        when :fail, :error then red(string)
+        when :skip then yellow(string)
         else green(string)
         end
       end
 
       def suite_result
-        case
-        when failures > 0; :fail
-        when errors > 0; :error
-        when skips > 0; :skip
+        if failures.nonzero? then :fail
+        elsif errors.nonzero? then :error
+        elsif skips.nonzero? then :skip
         else :pass
         end
       end
@@ -190,6 +194,7 @@ module Minitest
 
         exception.backtrace.reverse_each do |s|
           break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
+
           last_before_assertion = s
         end
 

--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -45,6 +45,7 @@ module Minitest
       def friendly_name(test)
         groups = test.name.scan(/(test_\d+_)(.*)/i)
         return test.name if groups.empty?
+
         "it #{groups[0][1]}"
       end
 
@@ -57,6 +58,7 @@ module Minitest
       def initialize(args = {})
         super({})
 
+        # rubocop:disable Layout/AlignHash
         defaults = {
           :title           => 'Test Results',
           :erb_template    => "#{File.dirname(__FILE__)}/../templates/index.html.erb",
@@ -64,6 +66,7 @@ module Minitest
           :mode            => :safe,
           :output_filename => 'index.html',
         }
+        # rubocop:enable Layout/AlignHash
 
         settings = defaults.merge(args)
 
@@ -205,6 +208,7 @@ module Minitest
         last_before_assertion = ''
         exception.backtrace.reverse_each do |s|
           break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
+
           last_before_assertion = s
         end
         last_before_assertion.sub(/:in .*$/, '')

--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -45,7 +45,6 @@ module Minitest
       def friendly_name(test)
         groups = test.name.scan(/(test_\d+_)(.*)/i)
         return test.name if groups.empty?
-
         "it #{groups[0][1]}"
       end
 
@@ -58,7 +57,6 @@ module Minitest
       def initialize(args = {})
         super({})
 
-        # rubocop:disable Layout/AlignHash
         defaults = {
           :title           => 'Test Results',
           :erb_template    => "#{File.dirname(__FILE__)}/../templates/index.html.erb",
@@ -66,7 +64,6 @@ module Minitest
           :mode            => :safe,
           :output_filename => 'index.html',
         }
-        # rubocop:enable Layout/AlignHash
 
         settings = defaults.merge(args)
 
@@ -208,7 +205,6 @@ module Minitest
         last_before_assertion = ''
         exception.backtrace.reverse_each do |s|
           break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
-
           last_before_assertion = s
         end
         last_before_assertion.sub(/:in .*$/, '')

--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -16,20 +16,20 @@ module Minitest
         @single_file = options[:single_file]
         @base_path = options[:base_path] || Dir.pwd
 
-        if empty
-          puts "Emptying #{@reports_path}"
-          FileUtils.mkdir_p(@reports_path)
-          File.delete(*Dir.glob("#{@reports_path}/TEST-*.xml"))
-        end
+        return unless empty
+
+        puts "Emptying #{@reports_path}"
+        FileUtils.mkdir_p(@reports_path)
+        File.delete(*Dir.glob("#{@reports_path}/TEST-*.xml"))
       end
 
       def report
         super
 
         puts "Writing XML reports to #{@reports_path}"
-        suites = tests.group_by { |test|
+        suites = tests.group_by do |test|
           test_class(test)
-        }
+        end
 
         if @single_file
           xml = Builder::XmlMarkup.new(:indent => 2)
@@ -130,6 +130,7 @@ module Minitest
         last_before_assertion = ''
         exception.backtrace.reverse_each do |s|
           break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
+
           last_before_assertion = s
         end
         last_before_assertion.sub(/:in .*$/, '')
@@ -155,7 +156,9 @@ module Minitest
         while File.exist?(File.join(@reports_path, filename)) # restrict number of tries, to avoid infinite loops
           file_counter += 1
           filename = "TEST-#{suite_name}-#{file_counter}.xml"
+          # rubocop:disable Style/AndOr
           puts "Too many duplicate files, overwriting earlier report #{filename}" and break if file_counter >= 99
+          # rubocop:enable Style/AndOr
         end
         File.join(@reports_path, filename)
       end

--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -16,20 +16,20 @@ module Minitest
         @single_file = options[:single_file]
         @base_path = options[:base_path] || Dir.pwd
 
-        return unless empty
-
-        puts "Emptying #{@reports_path}"
-        FileUtils.mkdir_p(@reports_path)
-        File.delete(*Dir.glob("#{@reports_path}/TEST-*.xml"))
+        if empty
+          puts "Emptying #{@reports_path}"
+          FileUtils.mkdir_p(@reports_path)
+          File.delete(*Dir.glob("#{@reports_path}/TEST-*.xml"))
+        end
       end
 
       def report
         super
 
         puts "Writing XML reports to #{@reports_path}"
-        suites = tests.group_by do |test|
+        suites = tests.group_by { |test|
           test_class(test)
-        end
+        }
 
         if @single_file
           xml = Builder::XmlMarkup.new(:indent => 2)
@@ -130,7 +130,6 @@ module Minitest
         last_before_assertion = ''
         exception.backtrace.reverse_each do |s|
           break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
-
           last_before_assertion = s
         end
         last_before_assertion.sub(/:in .*$/, '')
@@ -156,9 +155,7 @@ module Minitest
         while File.exist?(File.join(@reports_path, filename)) # restrict number of tries, to avoid infinite loops
           file_counter += 1
           filename = "TEST-#{suite_name}-#{file_counter}.xml"
-          # rubocop:disable Style/AndOr
           puts "Too many duplicate files, overwriting earlier report #{filename}" and break if file_counter >= 99
-          # rubocop:enable Style/AndOr
         end
         File.join(@reports_path, filename)
       end

--- a/lib/minitest/reporters/mean_time_reporter.rb
+++ b/lib/minitest/reporters/mean_time_reporter.rb
@@ -119,6 +119,7 @@ module Minitest
       #   and the number of tests to output to output to the screen after each
       #   run.
       def defaults
+        # rubocop:disable Layout/AlignHash
         {
           order:                  :desc,
           show_count:             15,
@@ -128,6 +129,7 @@ module Minitest
           previous_runs_filename: File.join(Dir.tmpdir, 'minitest_reporters_previous_run'),
           report_filename:        File.join(Dir.tmpdir, 'minitest_reporters_report'),
         }
+        # rubocop:enable Layout/AlignHash
       end
 
       # Added to the top of the report file and to the screen output.
@@ -172,6 +174,7 @@ module Minitest
       #   the :sort_column option. (Defaults to :avg).
       def column_sorted_body
         runs = options[:show_all_runs] ? previous_run : current_run
+        # rubocop:disable Style/MultilineBlockChain, Layout/AlignHash
         runs.keys.each_with_object([]) do |description, obj|
           timings = previous_run[description]
           size = Array(timings).size
@@ -184,6 +187,7 @@ module Minitest
             desc: description,
           }
         end.sort_by { |k| k[sort_column] }
+        # rubocop:enable Style/MultilineBlockChain, Layout/AlignHash
       end
 
       # @return [Hash]
@@ -357,14 +361,14 @@ module Minitest
       #   When the given :order option is invalid.
       # @return [Symbol] The :order option, or by default; :desc.
       def order
-        orders = [:desc, :asc]
+        orders = %i[desc asc]
 
         if orders.include?(options[:order])
           options[:order]
 
         else
-          fail Minitest::Reporters::MeanTimeReporter::InvalidOrder,
-               "`:order` option must be one of #{orders.inspect}."
+          raise Minitest::Reporters::MeanTimeReporter::InvalidOrder,
+                "`:order` option must be one of #{orders.inspect}."
 
         end
       end
@@ -373,14 +377,14 @@ module Minitest
       #   When the given :sort_column option is invalid.
       # @return [Symbol] The :sort_column option, or by default; :avg.
       def sort_column
-        sort_columns = [:avg, :min, :max, :last]
+        sort_columns = %i[avg min max last]
 
         if sort_columns.include?(options[:sort_column])
           options[:sort_column]
 
         else
-          fail Minitest::Reporters::MeanTimeReporter::InvalidSortColumn,
-               "`:sort_column` option must be one of #{sort_columns.inspect}."
+          raise Minitest::Reporters::MeanTimeReporter::InvalidSortColumn,
+                "`:sort_column` option must be one of #{sort_columns.inspect}."
 
         end
       end

--- a/lib/minitest/reporters/mean_time_reporter.rb
+++ b/lib/minitest/reporters/mean_time_reporter.rb
@@ -1,4 +1,5 @@
 require 'minitest/reporters'
+require 'fileutils'
 require 'tmpdir'
 require 'yaml'
 
@@ -95,12 +96,12 @@ module Minitest
         super if options[:show_progress]
       end
 
-      # Resets the 'previous runs' file, essentially removing all previous
-      # statistics gathered.
+      # Deletes the 'previous runs' file, removing all previous statistics
+      # gathered.
       #
       # @return [void]
       def reset_statistics!
-        File.open(previous_runs_filename, 'w+') { |f| f.write('') }
+        FileUtils.rm_f(previous_runs_filename) # no error if file doesn't exist
       end
 
       protected

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -19,6 +19,7 @@ module Minitest
         super
         @detailed_skip = options.fetch(:detailed_skip, true)
 
+        # rubocop:disable Layout/AlignHash
         @progress = ProgressBar.create(
           total:          total_count,
           starting_at:    count,
@@ -27,6 +28,7 @@ module Minitest
           format:         options.fetch(:format, '  %C/%c: [%B] %p%% %a, %e'),
           autostart:      false
         )
+        # rubocop:enable Layout/AlignHash
       end
 
       def start
@@ -41,6 +43,7 @@ module Minitest
       def record(test)
         super
         return if test.skipped? && !@detailed_skip
+
         if test.failure
           print "\e[0m\e[1000D\e[K"
           print_colored_status(test)
@@ -75,7 +78,7 @@ module Minitest
       private
 
       def show
-        @progress.increment unless count == 0
+        @progress.increment unless count.zero?
       end
 
       def print_test_with_time(test)

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -19,7 +19,6 @@ module Minitest
         super
         @detailed_skip = options.fetch(:detailed_skip, true)
 
-        # rubocop:disable Layout/AlignHash
         @progress = ProgressBar.create(
           total:          total_count,
           starting_at:    count,
@@ -28,7 +27,6 @@ module Minitest
           format:         options.fetch(:format, '  %C/%c: [%B] %p%% %a, %e'),
           autostart:      false
         )
-        # rubocop:enable Layout/AlignHash
       end
 
       def start
@@ -43,7 +41,6 @@ module Minitest
       def record(test)
         super
         return if test.skipped? && !@detailed_skip
-
         if test.failure
           print "\e[0m\e[1000D\e[K"
           print_colored_status(test)
@@ -78,7 +75,7 @@ module Minitest
       private
 
       def show
-        @progress.increment unless count.zero?
+        @progress.increment unless count == 0
       end
 
       def print_test_with_time(test)

--- a/lib/minitest/reporters/rubymine_reporter.rb
+++ b/lib/minitest/reporters/rubymine_reporter.rb
@@ -55,8 +55,8 @@ else
 
           puts('Finished in %.5fs' % total_time)
           print('%d tests, %d assertions, ' % [count, assertions])
-          print(red('%d failures, %d errors, ' % [failures, errors]))
-          print(yellow('%d skips' % skips))
+          print(red '%d failures, %d errors, ' % [failures, errors])
+          print(yellow '%d skips' % skips)
           puts
         end
 

--- a/lib/minitest/reporters/rubymine_reporter.rb
+++ b/lib/minitest/reporters/rubymine_reporter.rb
@@ -55,8 +55,8 @@ else
 
           puts('Finished in %.5fs' % total_time)
           print('%d tests, %d assertions, ' % [count, assertions])
-          print(red '%d failures, %d errors, ' % [failures, errors])
-          print(yellow '%d skips' % skips)
+          print(red('%d failures, %d errors, ' % [failures, errors]))
+          print(yellow('%d skips' % skips))
           puts
         end
 

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -51,10 +51,10 @@ module Minitest
       end
 
       def record_print_failures_if_any(test)
-        return if test.skipped? || !test.failure
-
-        print_info(test.failure, test.error?)
-        puts
+        if !test.skipped? && test.failure
+          print_info(test.failure, test.error?)
+          puts
+        end
       end
     end
   end

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -51,10 +51,10 @@ module Minitest
       end
 
       def record_print_failures_if_any(test)
-        if !test.skipped? && test.failure
-          print_info(test.failure, test.error?)
-          puts
-        end
+        return if test.skipped? || !test.failure
+
+        print_info(test.failure, test.error?)
+        puts
       end
     end
   end

--- a/test/fixtures/mean_time_detailed_skip_test.rb
+++ b/test/fixtures/mean_time_detailed_skip_test.rb
@@ -3,6 +3,6 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require 'minitest/reporters/mean_time_reporter'
 
-Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new
+Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new(detailed_skip: false)
 
 require_relative './separate_sample_test'

--- a/test/fixtures/mean_time_hide_all_runs_test.rb
+++ b/test/fixtures/mean_time_hide_all_runs_test.rb
@@ -3,6 +3,6 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require 'minitest/reporters/mean_time_reporter'
 
-Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new
+Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new(show_all_runs: false)
 
 require_relative './separate_sample_test'

--- a/test/fixtures/mean_time_hide_progress_test.rb
+++ b/test/fixtures/mean_time_hide_progress_test.rb
@@ -3,6 +3,6 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require 'minitest/reporters/mean_time_reporter'
 
-Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new
+Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new(show_progress: false)
 
 require_relative './separate_sample_test'

--- a/test/fixtures/mean_time_show_count_test.rb
+++ b/test/fixtures/mean_time_show_count_test.rb
@@ -3,6 +3,6 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require 'minitest/reporters/mean_time_reporter'
 
-Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new
+Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new(show_count: 3)
 
 require_relative './separate_sample_test'

--- a/test/fixtures/mean_time_show_count_test.rb
+++ b/test/fixtures/mean_time_show_count_test.rb
@@ -3,6 +3,6 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require 'minitest/reporters/mean_time_reporter'
 
-Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new(show_count: 3)
+Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new(show_count: 2)
 
 require_relative './separate_sample_test'

--- a/test/fixtures/mean_time_sort_ascending_test.rb
+++ b/test/fixtures/mean_time_sort_ascending_test.rb
@@ -3,6 +3,6 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require 'minitest/reporters/mean_time_reporter'
 
-Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new
+Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new(order: :asc)
 
 require_relative './separate_sample_test'

--- a/test/fixtures/mean_time_sort_by_max_test.rb
+++ b/test/fixtures/mean_time_sort_by_max_test.rb
@@ -3,6 +3,6 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require 'minitest/reporters/mean_time_reporter'
 
-Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new
+Minitest::Reporters.use! Minitest::Reporters::MeanTimeReporter.new(sort_column: :max)
 
 require_relative './separate_sample_test'

--- a/test/fixtures/separate_sample_test.rb
+++ b/test/fixtures/separate_sample_test.rb
@@ -1,0 +1,29 @@
+class TestClass < Minitest::Test
+  def test_assertion
+    assert true
+  end
+
+  def test_fail
+    assert false
+  end
+end
+
+class AnotherTestClass < Minitest::Test
+  def test_assertion
+    assert true
+  end
+
+  def test_skip
+    skip 'Skipping rope...'
+  end
+end
+
+class LastTestClass < Minitest::Test
+  def test_assertion
+    assert true
+  end
+
+  def test_error
+    raise 'An unexpected error'
+  end
+end

--- a/test/integration/reporters/mean_time_reporter_test.rb
+++ b/test/integration/reporters/mean_time_reporter_test.rb
@@ -2,6 +2,92 @@ require_relative "../../test_helper"
 
 module MinitestReportersTest
   class MeanTimeReporterTest < TestCase
+    def test_all_failures_are_displayed
+      fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
+      test_filename = File.join(fixtures_directory, 'mean_time_test.rb')
+      # ----
+      output = `#{ruby_executable} #{test_filename} 2>&1`
+      # ----
+      assert_match "Error:\nLastTestClass#test_error:", output,
+        'Errors should be displayed'
+      assert_match "Failure:\nTestClass#test_fail ", output,
+        'Failures should be displayed'
+      assert_match "Skipped:\nAnotherTestClass#test_skip ", output,
+        'Skipped tests should be displayed'
+    end
 
+    def test_skipped_tests_are_not_displayed
+      fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
+      test_filename = File.join(fixtures_directory, 'mean_time_detailed_skip_test.rb')
+      # ----
+      output = `#{ruby_executable} #{test_filename} 2>&1`
+      # ----
+      assert_match "Error:\nLastTestClass#test_error:", output,
+        'Errors should be displayed'
+      assert_match "Failure:\nTestClass#test_fail ", output,
+        'Failures should be displayed'
+      refute_match "Skipped:\nAnotherTestClass#test_skip ", output,
+        'Skipped tests should not be displayed'
+    end
+
+    def test_show_count_limits_count
+      fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
+      test_filename = File.join(fixtures_directory, 'mean_time_test.rb')
+      base_output = `#{ruby_executable} #{test_filename} 2>&1`
+      base_count = base_output.lines.select { |s| s.match? /^Avg: / }.count
+      # ----
+      test_filename = File.join(fixtures_directory, 'mean_time_show_count_test.rb')
+      output = `#{ruby_executable} #{test_filename} 2>&1`
+      count = output.lines.select { |s| s.match? /^Avg: / }.count
+      refute_equal count, base_count, 'show_count had no effect'
+    end
+
+    def test_progress_is_not_displayed
+      fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
+      test_filename = File.join(fixtures_directory, 'mean_time_hide_progress_test.rb')
+      # ----
+      output = `#{ruby_executable} #{test_filename} 2>&1`
+      # ----
+      refute_match 'Error:', output, 'Errors should not be displayed'
+      refute_match 'Failure:', output, 'Failures should not be displayed'
+      refute_match 'Skipped:', output, 'Skipped tests should not be displayed'
+    end
+
+    # As a reminder, when set to false, this omits the total time spent running
+    # all test, which in this case will have as a "Description" the class name
+    # of this test suite, `MinitestReportersTest::MeanTimeReporterTest`.
+    def test_dont_show_all_runs
+      fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
+      test_filename = File.join(fixtures_directory, 'mean_time_hide_all_runs_test.rb')
+      # ----
+      output = `#{ruby_executable} #{test_filename} 2>&1`
+      # ----
+      refute_match "Description: #{self.class.name}", output,
+        'Total for all runs should not be displayed'
+    end
+
+    def test_sort_by_max_time
+      fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
+      test_filename = File.join(fixtures_directory, 'mean_time_sort_by_max_test.rb')
+      # ----
+      output = `#{ruby_executable} #{test_filename} 2>&1`
+      # ----
+      assert_match 'Order: :max :desc', output, 'Output not sorted by max timing'
+    end
+
+    def test_sort_in_ascending_order
+      fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
+      test_filename = File.join(fixtures_directory, 'mean_time_sort_ascending_test.rb')
+      # ----
+      output = `#{ruby_executable} #{test_filename} 2>&1`
+      # ----
+      assert_match 'Order: :avg :asc', output, 'Output not sorted in ascending order'
+    end
+
+    private
+
+    def ruby_executable
+      defined?(JRUBY_VERSION) ? 'jruby' : 'ruby'
+    end
   end
 end

--- a/test/integration/reporters/mean_time_reporter_test.rb
+++ b/test/integration/reporters/mean_time_reporter_test.rb
@@ -75,11 +75,11 @@ module MinitestReportersTest
       fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
       test_filename = File.join(fixtures_directory, 'mean_time_test.rb')
       base_output = `#{ruby_executable} #{test_filename} 2>&1`
-      base_count = base_output.lines.select { |s| s.match? /^Avg: / }.count
+      base_count = base_output.lines.select { |s| s.match?(/^Avg: /) }.count
       # ----
       test_filename = File.join(fixtures_directory, 'mean_time_show_count_test.rb')
       output = `#{ruby_executable} #{test_filename} 2>&1`
-      count = output.lines.select { |s| s.match? /^Avg: / }.count
+      count = output.lines.select { |s| s.match?(/^Avg: /) }.count
       refute_equal count, base_count, 'show_count had no effect'
     end
 

--- a/test/integration/reporters/mean_time_reporter_test.rb
+++ b/test/integration/reporters/mean_time_reporter_test.rb
@@ -1,7 +1,48 @@
 require_relative "../../test_helper"
 
+require 'fileutils'
+
 module MinitestReportersTest
   class MeanTimeReporterTest < TestCase
+    # Uncomment this to verify breakage in minitest-reporters 1.3.5 as released
+    # def test_reset_statistics_breaks_future_runs
+    #   fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
+    #   test_filename = File.join(fixtures_directory, 'mean_time_test.rb')
+    #   prev_runs_file = Dir.tmpdir + '/minitest_reporters_previous_run'
+    #   FileUtils.rm_f(prev_runs_file) # Erase any previous-runs data file
+    #   # ----
+    #   output1 = `#{ruby_executable} #{test_filename} 2>&1`
+    #   assert_equal(output1.lines[0], "\n") # start of successful-run report
+    #   # ----
+    #   Minitest::Reporters::MeanTimeReporter.reset_statistics!
+    #   assert_equal(true, File.empty?(prev_runs_file)) # exists and is empty
+    #   # ----
+    #   output2 = `#{ruby_executable} #{test_filename} 2>&1`
+    #   expected = "`block in create_or_update_previous_runs!': " \
+    #     "undefined method `[]' for false:FalseClass (NoMethodError)"
+    #   assert_match expected, output2, 'Did not get expected exception message'
+    #   FileUtils.rm_f(prev_runs_file) # Remove broken previous-runs data file
+    # end
+
+    def test_reset_statistics_does_not_break_future_runs
+      fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
+      test_filename = File.join(fixtures_directory, 'mean_time_test.rb')
+      prev_runs_file = Dir.tmpdir + '/minitest_reporters_previous_run'
+      FileUtils.rm_f(prev_runs_file) # Erase any previous-runs data file
+      # ----
+      output1 = `#{ruby_executable} #{test_filename} 2>&1`
+      assert_equal(output1.lines[0], "\n") # start of successful-run report
+      # ----
+      Minitest::Reporters::MeanTimeReporter.reset_statistics!
+      assert_equal(false, File.exists?(prev_runs_file))
+      # ----
+      output2 = `#{ruby_executable} #{test_filename} 2>&1`
+      error_message = "`block in create_or_update_previous_runs!': " \
+        "undefined method `[]' for false:FalseClass (NoMethodError)"
+      refute_match error_message, output2, 'Got unexpected exception message'
+      FileUtils.rm_f(prev_runs_file) # Erase any previous-runs data file on fail
+    end
+
     def test_all_failures_are_displayed
       fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
       test_filename = File.join(fixtures_directory, 'mean_time_test.rb')

--- a/test/integration/reporters/mean_time_reporter_test.rb
+++ b/test/integration/reporters/mean_time_reporter_test.rb
@@ -34,7 +34,7 @@ module MinitestReportersTest
       assert_equal(output1.lines[0], "\n") # start of successful-run report
       # ----
       Minitest::Reporters::MeanTimeReporter.reset_statistics!
-      assert_equal(false, File.exists?(prev_runs_file))
+      assert_equal(false, File.exist?(prev_runs_file))
       # ----
       output2 = `#{ruby_executable} #{test_filename} 2>&1`
       error_message = "`block in create_or_update_previous_runs!': " \

--- a/test/integration/reporters/mean_time_reporter_test.rb
+++ b/test/integration/reporters/mean_time_reporter_test.rb
@@ -75,11 +75,11 @@ module MinitestReportersTest
       fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
       test_filename = File.join(fixtures_directory, 'mean_time_test.rb')
       base_output = `#{ruby_executable} #{test_filename} 2>&1`
-      base_count = base_output.lines.select { |s| s.match?(/^Avg: /) }.count
+      base_count = base_output.lines.select { |s| s.match(/^Avg: /) }.count
       # ----
       test_filename = File.join(fixtures_directory, 'mean_time_show_count_test.rb')
       output = `#{ruby_executable} #{test_filename} 2>&1`
-      count = output.lines.select { |s| s.match?(/^Avg: /) }.count
+      count = output.lines.select { |s| s.match(/^Avg: /) }.count
       refute_equal count, base_count, 'show_count had no effect'
     end
 

--- a/test/unit/minitest/reporters_test.rb
+++ b/test/unit/minitest/reporters_test.rb
@@ -7,16 +7,16 @@ module MinitestReportersTest
       # Rubymine reporter complains when RubyMine libs are not available, so
       # stub its #puts method out.
       $stdout.stub :puts, nil do
-        reporters = Minitest::Reporters.choose_reporters [], { "RM_INFO" => "x" }
+        reporters = Minitest::Reporters.choose_reporters [], "RM_INFO" => "x"
         assert_instance_of Minitest::Reporters::RubyMineReporter, reporters[0]
 
-        reporters = Minitest::Reporters.choose_reporters [], { "TEAMCITY_VERSION" => "x" }
+        reporters = Minitest::Reporters.choose_reporters [], "TEAMCITY_VERSION" => "x"
         assert_instance_of Minitest::Reporters::RubyMineReporter, reporters[0]
       end
     end
 
     def test_chooses_the_textmate_reporter_when_necessary
-      reporters = Minitest::Reporters.choose_reporters [], {"TM_PID" => "x"}
+      reporters = Minitest::Reporters.choose_reporters [], "TM_PID" => "x"
       assert_instance_of Minitest::Reporters::RubyMateReporter, reporters[0]
     end
 
@@ -27,22 +27,26 @@ module MinitestReportersTest
 
     def test_chooses_no_reporters_when_running_under_vim
       reporters = Minitest::Reporters.choose_reporters(
-        [Minitest::Reporters::DefaultReporter.new], { "VIM" => "/usr/share/vim" })
+        [Minitest::Reporters::DefaultReporter.new], "VIM" => "/usr/share/vim"
+      )
       assert_nil reporters
     end
 
+    # rubocop:disable Naming/MethodName
     def test_chooses_given_reporter_when_MINITEST_REPORTERS_env_set
       env = {
-        "MINITEST_REPORTER" => "JUnitReporter", 
-        "RM_INFO" => "x", 
-        "TEAMCITY_VERSION" => "x", 
-        "TM_PID" => "x" }
+        "MINITEST_REPORTER" => "JUnitReporter",
+        "RM_INFO" => "x",
+        "TEAMCITY_VERSION" => "x",
+        "TM_PID" => "x",
+      }
       # JUnit reporter init has stdout messages... capture them to keep test output clean
       $stdout.stub :puts, nil do
         reporters = Minitest::Reporters.choose_reporters [], env
         assert_instance_of Minitest::Reporters::JUnitReporter, reporters[0]
       end
     end
+    # rubocop:enable Naming/MethodName
 
     def test_uses_minitest_clock_time_when_minitest_version_greater_than_561
       Minitest::Reporters.stub :minitest_version, 583 do

--- a/test/unit/minitest/reporters_test.rb
+++ b/test/unit/minitest/reporters_test.rb
@@ -7,16 +7,16 @@ module MinitestReportersTest
       # Rubymine reporter complains when RubyMine libs are not available, so
       # stub its #puts method out.
       $stdout.stub :puts, nil do
-        reporters = Minitest::Reporters.choose_reporters [], "RM_INFO" => "x"
+        reporters = Minitest::Reporters.choose_reporters [], { "RM_INFO" => "x" }
         assert_instance_of Minitest::Reporters::RubyMineReporter, reporters[0]
 
-        reporters = Minitest::Reporters.choose_reporters [], "TEAMCITY_VERSION" => "x"
+        reporters = Minitest::Reporters.choose_reporters [], { "TEAMCITY_VERSION" => "x" }
         assert_instance_of Minitest::Reporters::RubyMineReporter, reporters[0]
       end
     end
 
     def test_chooses_the_textmate_reporter_when_necessary
-      reporters = Minitest::Reporters.choose_reporters [], "TM_PID" => "x"
+      reporters = Minitest::Reporters.choose_reporters [], {"TM_PID" => "x"}
       assert_instance_of Minitest::Reporters::RubyMateReporter, reporters[0]
     end
 
@@ -27,26 +27,22 @@ module MinitestReportersTest
 
     def test_chooses_no_reporters_when_running_under_vim
       reporters = Minitest::Reporters.choose_reporters(
-        [Minitest::Reporters::DefaultReporter.new], "VIM" => "/usr/share/vim"
-      )
+        [Minitest::Reporters::DefaultReporter.new], { "VIM" => "/usr/share/vim" })
       assert_nil reporters
     end
 
-    # rubocop:disable Naming/MethodName
     def test_chooses_given_reporter_when_MINITEST_REPORTERS_env_set
       env = {
-        "MINITEST_REPORTER" => "JUnitReporter",
-        "RM_INFO" => "x",
-        "TEAMCITY_VERSION" => "x",
-        "TM_PID" => "x",
-      }
+        "MINITEST_REPORTER" => "JUnitReporter", 
+        "RM_INFO" => "x", 
+        "TEAMCITY_VERSION" => "x", 
+        "TM_PID" => "x" }
       # JUnit reporter init has stdout messages... capture them to keep test output clean
       $stdout.stub :puts, nil do
         reporters = Minitest::Reporters.choose_reporters [], env
         assert_instance_of Minitest::Reporters::JUnitReporter, reporters[0]
       end
     end
-    # rubocop:enable Naming/MethodName
 
     def test_uses_minitest_clock_time_when_minitest_version_greater_than_561
       Minitest::Reporters.stub :minitest_version, 583 do

--- a/test/unit/minitest/spec_reporter_test.rb
+++ b/test/unit/minitest/spec_reporter_test.rb
@@ -51,7 +51,7 @@ module MinitestReportersTest
       error_msg = nil
       begin
         @reporter.report
-      rescue => e # rubocop:disable Style/RescueStandardError ## FIXME ##
+      rescue => e
         error_msg = "error executing @reporter.report, #{e}"
       end
 
@@ -59,3 +59,4 @@ module MinitestReportersTest
     end
   end
 end
+

--- a/test/unit/minitest/spec_reporter_test.rb
+++ b/test/unit/minitest/spec_reporter_test.rb
@@ -51,7 +51,7 @@ module MinitestReportersTest
       error_msg = nil
       begin
         @reporter.report
-      rescue => e
+      rescue => e # rubocop:disable Style/RescueStandardError ## FIXME ##
         error_msg = "error executing @reporter.report, #{e}"
       end
 
@@ -59,4 +59,3 @@ module MinitestReportersTest
     end
   end
 end
-


### PR DESCRIPTION
As noted in #271, [`Minitest::Reporters::MeanTimeReporter#reset_statistics!`](https://github.com/kern/minitest-reporters/blob/master/lib/minitest/reporters/mean_time_reporter.rb#L103) is inconsistent with the test in [`Minitest::Reporters::MeanTimeReporter#previously_ran?`](https://github.com/kern/minitest-reporters/blob/master/lib/minitest/reporters/mean_time_reporter.rb#L216), and that crashes each future Minitest run until the previous-runs file is manually deleted. This changes the `#reset_statistics` method to delete the file instead of overwriting it with an empty file, as is presently done.

Before that commit (#edb7e2d), we replace [the empty `MeanTimeReporterTest` class](https://github.com/kern/minitest-reporters/blob/d28c3ad9630234a306359534191ad4c8ba35bbfc/test/integration/reporters/mean_time_reporter_test.rb) with a class containing tests proving that all constructor options to `MeanTimeReporter` work as expected.

Finally, we make first `MeanTimeReporter`, then all other source files in `lib` RuboCop-clean, either by repairing the offending lines of code or by wrapping them in comments which disable the relevent "cops" over the offending lines. We also modify the `Rakefile` to run the `rubocop` task after successful completion of the `test` task by default, so that later changes to *files in the `lib` directory only* will have those changes inspected by RuboCop. The `Rakefile` *does not* presently run RuboCop against test files; we **recommend** that files matching `test/**/*_test.rb` be made RuboCop-clean in a future PR, with the `Rakefile` properly adjusted at that time.