### PR TITLE
Handle missing suite in BaseReporter#report

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -56,7 +56,9 @@ module Minitest
 
       def report
         super
-        after_suite(test_class(tests.last))
+        if last_suite = test_class(tests.last)
+          after_suite(last_suite)
+        end
       end
 
       protected


### PR DESCRIPTION
That case is handled [in other places](https://github.com/kern/minitest-reporters/blob/6cf30e76d3f37d8181e6d9a2a0f45ea870dc0abd/lib/minitest/reporters/base_reporter.rb#L45), but not here.

In some weird corner cases it can cause the following issue:
```
gems/minitest-reporters-1.3.5/lib/minitest/reporters/default_reporter.rb:49:in `after_suite': undefined method `name' for nil:NilClass (NoMethodError)
gems/minitest-reporters-1.3.5/lib/minitest/reporters/base_reporter.rb:59:in `report'
gems/minitest-reporters-1.3.5/lib/minitest/reporters/default_reporter.rb:89:in `report'
gems/minitest-reporters-1.3.5/lib/minitest/minitest_reporter_plugin.rb:26:in `each'
gems/minitest-reporters-1.3.5/lib/minitest/minitest_reporter_plugin.rb:26:in `report'
gems/minitest-5.11.3/lib/minitest.rb:808:in `each'
gems/minitest-5.11.3/lib/minitest.rb:808:in `report'
gems/minitest-5.11.3/lib/minitest.rb:141:in `run'
gems/minitest-5.11.3/lib/minitest.rb:63:in `block in autorun'
```