### PR TITLE
Release 1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### [dev](https://github.com/kern/minitest-reporters/compare/v1.3.5...master)
+### [dev](https://github.com/kern/minitest-reporters/compare/v1.3.6...master)
+
+### [1.3.6](https://github.com/kern/minitest-reporters/compare/v1.3.5...v1.3.6)
 
 * fixed possible null pointer in #after_suite [#274](https://github.com/kern/minitest-reporters/pull/274)
   contributed by [casperisfine](https://github.com/casperisfine)

--- a/lib/minitest/reporters/version.rb
+++ b/lib/minitest/reporters/version.rb
@@ -1,5 +1,5 @@
 module Minitest
   module Reporters
-    VERSION = '1.3.5'.freeze
+    VERSION = '1.3.6'.freeze
   end
 end


### PR DESCRIPTION
Hey 👋 

A project I maintain is pulling in master to gain the fix made in #274. Would it be possible to cut a new version so that this Gem can be fetched from RubyGems?

This PR follows the changes for a new release as demonstrated in 6cf30e76d3f37d8181e6d9a2a0f45ea870dc0abd

Thanks!