### PR TITLE
Add ability to set reports directory via environment variable

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -10,9 +10,13 @@ module Minitest
     # Also inspired by Marc Seeger's attempt at producing a JUnitReporter (see https://github.com/rb2k/minitest-reporters/commit/e13d95b5f884453a9c77f62bc5cba3fa1df30ef5)
     # Also inspired by minitest-ci (see https://github.com/bhenderson/minitest-ci)
     class JUnitReporter < BaseReporter
-      def initialize(reports_dir = "test/reports", empty = true, options = {})
+      DEFAULT_REPORTS_DIR = "test/reports".freeze
+
+      attr_reader :reports_path
+
+      def initialize(reports_dir = DEFAULT_REPORTS_DIR, empty = true, options = {})
         super({})
-        @reports_path = File.absolute_path(reports_dir)
+        @reports_path = File.absolute_path(ENV.fetch("MINITEST_REPORTERS_REPORTS_DIR", reports_dir))
         @single_file = options[:single_file]
         @base_path = options[:base_path] || Dir.pwd
 

--- a/test/unit/minitest/junit_reporter_test.rb
+++ b/test/unit/minitest/junit_reporter_test.rb
@@ -17,7 +17,30 @@ module MinitestReportersTest
       relative_path = @reporter.get_relative_path(@result)
       assert_equal path, relative_path.to_s
     end
+
+    def test_defaults_reports_path
+      reporter = Minitest::Reporters::JUnitReporter.new
+      expected_reports_dir = Minitest::Reporters::JUnitReporter::DEFAULT_REPORTS_DIR
+      expected_reports_path = File.absolute_path(expected_reports_dir)
+      assert_equal expected_reports_path, reporter.reports_path
+    end
+
+    def test_accepts_custom_report_dir_using_env
+      expected_reports_dir = "test_reports"
+      expected_reports_path = File.absolute_path(expected_reports_dir)
+      with_env("MINITEST_REPORTERS_REPORTS_DIR" => expected_reports_dir) do
+        reporter = Minitest::Reporters::JUnitReporter.new
+        assert_equal expected_reports_path, reporter.reports_path
+      end
+    end
+
+    private
+
+    def with_env(hash)
+      original_env = ENV.to_hash
+      ENV.update(hash)
+      yield
+      ENV.replace(original_env)
+    end
   end
 end
-
-


### PR DESCRIPTION
This pull request add the ability to specify the reports directory via an environment variable. This is especially useful when setting the given reporter via the environment variable `MINITEST_REPORTER`.

Further, we're currently using Bitbucket Pipeline for CI purposes. They enforce certain expectations on where the Xunit-compatible output is located. Currently, we check for the `CI` environment variable in our `test_helper.rb` and change the reporter and the expected reports directory as needed. With this change, we could just set `MINITEST_REPORTER` and `MINITEST_REPORTERS_REPORTS_DIR` in our Bitbucket environment and remove any custom changes made explicitly for Bitbucket from our `test_helper.rb`.