### PR TITLE
Adding verbose functionality to progress_reporter

### DIFF
--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -37,6 +37,11 @@ module Minitest
         @progress.total = total_count
         show
       end
+      
+      def before_test(test)
+        super
+        print "\n#{test.class}##{test.name} " if options[:verbose]
+      end
 
       def record(test)
         super

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -37,10 +37,11 @@ module Minitest
         @progress.total = total_count
         show
       end
-      
+
       def before_test(test)
         super
-        print "\n#{test.class}##{test.name} " if options[:verbose]
+        puts
+        puts("\n%s#%s" % [test_class(test), test.name]) if options[:verbose]
       end
 
       def record(test)


### PR DESCRIPTION
Currently ProgressReporter ignores the verbose option (TESTOPTS="-v"). 

This patch adds the functionality similar to that is implemented in DefaultReporter (i.e., printing the name of the test before the test).

I chose to extend ProgressReporter so that I modify only one file but the best place for this functionality might be BaseReporter::before_test(test) so that every reporter inheriting from the base has the basic verbose functionality.

However, since DefaultReporter extends before_test(test) as well, whic would lead to double printing if we don't  modify such reporters which extends before_test(test) for verbose functionality.