### PR TITLE
Normalise friendly name usage

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -46,6 +46,13 @@ module Minitest
         before_suite(test_class(test))
       end
 
+      # Trims off the number prefix on test names when using Minitest Specs
+      def friendly_name(test)
+        groups = test.name.scan(/(test_\d+_)(.*)/i)
+        return test.name if groups.empty?
+        groups[0][1]
+      end
+
       def record(test)
         super
         tests << test

--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -43,9 +43,8 @@ module Minitest
 
       # Trims off the number prefix on test names when using Minitest Specs
       def friendly_name(test)
-        groups = test.name.scan(/(test_\d+_)(.*)/i)
-        return test.name if groups.empty?
-        "it #{groups[0][1]}"
+        name = super(test)
+        "it #{name}"
       end
 
       # The constructor takes a hash, and uses the following keys:

--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -79,7 +79,7 @@ module Minitest
                       :assertions => suite_result[:assertion_count], :time => suite_result[:time]) do
           tests.each do |test|
             lineno = get_source_location(test).last
-            xml.testcase(:name => test.name, :lineno => lineno, :classname => suite, :assertions => test.assertions,
+            xml.testcase(:name => friendly_name(test.name), :lineno => lineno, :classname => suite, :assertions => test.assertions,
                          :time => test.time) do
               xml << xml_message_for(test) unless test.passed?
             end
@@ -98,9 +98,9 @@ module Minitest
         e = test.failure
 
         if test.skipped?
-          xml.skipped(:type => test.name)
+          xml.skipped(:type => friendly_name(test.name))
         elsif test.error?
-          xml.error(:type => test.name, :message => xml.trunc!(e.message)) do
+          xml.error(:type => friendly_name(test.name), :message => xml.trunc!(e.message)) do
             xml.text!(message_for(test))
           end
         elsif test.failure
@@ -112,7 +112,7 @@ module Minitest
 
       def message_for(test)
         suite = test.class
-        name = test.name
+        name = friendly_name(test.name)
         e = test.failure
 
         if test.passed?


### PR DESCRIPTION
Normalize the use of `friendly_name` between the HTML and JUnit
reporters when reporting results for `Minitest::Spec`

#### Note
HTML and JUnit are not identical because I kept the HTML "It" prefix, none of the JUnit parsers / reporter systems I have seen display test names in a way that would have benefited from the "it".

I only use the HTML and JUnit reporters so I am not sure if any of the others would benefit from being normalised as well.
