### PR TITLE
gemspec: Drop rubyforge_project, it is EOL

### DIFF
--- a/minitest-reporters.gemspec
+++ b/minitest-reporters.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.required_ruby_version = '>= 1.9.3'
-  s.rubyforge_project = 'minitest-reporters'
 
   s.add_dependency 'minitest', '>= 5.0'
   s.add_dependency 'ansi'


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.