### PR TITLE
Use exception class for error, failure and skipped type

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -99,16 +99,16 @@ module Minitest
           txt.sub(/\n.*/m, '...')
         end
 
-        e = test.failure
+        failure = test.failure
 
         if test.skipped?
-          xml.skipped(:type => test.name)
+          xml.skipped(:type => failure.error.class.name)
         elsif test.error?
-          xml.error(:type => test.name, :message => xml.trunc!(e.message)) do
+          xml.error(:type => failure.error.class.name, :message => xml.trunc!(failure.message)) do
             xml.text!(message_for(test))
           end
-        elsif test.failure
-          xml.failure(:type => test.name, :message => xml.trunc!(e.message)) do
+        elsif failure
+          xml.failure(:type => failure.error.class.name, :message => xml.trunc!(failure.message)) do
             xml.text!(message_for(test))
           end
         end


### PR DESCRIPTION
Fixes #285

## Problem

Using the test name for the error or failure type didn't make sense, wasn't aligned with the [Apache Ant's JUnit XML schema description](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd) of the error type and wasn't useful by redundantly including the test name again in this field.

## Solution

Use the exception class name for the type of the skipped, failure and error elements.