### PR TITLE
Add a location option to show the starting line number for failing tests.

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -19,6 +19,7 @@ module Minitest
         @suite_times = []
         @suite_start_times = {}
         @fast_fail = options.fetch(:fast_fail, false)
+        @show_test_location = options.fetch(:location, false)
         @options = options
       end
 
@@ -141,10 +142,27 @@ module Minitest
         unless message.nil? || message.strip == ''
           puts
           puts colored_for(result(test), message)
+          if @show_test_location
+            location = get_source_location(test)
+            puts "\n\n#{relative_path(location[0])}:#{location[1]}"
+          end
+
         end
       end
 
       private
+
+      def relative_path(path)
+        Pathname.new(path).relative_path_from(Pathname.new(Dir.getwd))
+      end
+      
+      def get_source_location(result)
+        if result.respond_to? :klass
+          result.source_location
+        else
+          result.method(result.name).source_location
+        end
+      end
 
       def color?
         return @color if defined?(@color)
@@ -187,7 +205,6 @@ module Minitest
 
       def location(exception)
         last_before_assertion = ''
-
         exception.backtrace.reverse_each do |s|
           break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
           last_before_assertion = s


### PR DESCRIPTION
It's convenient to have the *starting line number* for a failing test be shown in addition to the exception information. 

This PR adds an option that enables this:
```
..F

Finished tests in 1.574018s, 1.9060 tests/s, 1.9060 assertions/s.


Failure:
UserTest#test_0003_example failing test [/Users/bmo/Documents/repo/trucentive/payette/test/models/user_test.rb:22]
Minitest::Assertion: Expected: false
  Actual: true


test/models/user_test.rb:21

3 tests, 3 assertions, 1 failures, 0 errors, 0 skips
```