### PR TITLE
Make DelegateReporter delegate #prerecord(klass, name)

### DIFF
--- a/lib/minitest/minitest_reporter_plugin.rb
+++ b/lib/minitest/minitest_reporter_plugin.rb
@@ -16,6 +16,12 @@ module Minitest
         all_reporters.each(&:start)
       end
 
+      def prerecord(klass, name)
+        all_reporters.each do |reporter|
+          reporter.prerecord klass, name
+        end
+      end
+
       def record(result)
         all_reporters.each do |reporter|
           reporter.record result


### PR DESCRIPTION
It must delegate `#prerecord` to show the method names of each test.
Because of the lack of delegation, Rails' test files don't print the
test method names even with `-v`.

Before this change:
```
Run options: -v --seed 29778

0.00 s = .
0.00 s = .
0.00 s = .
0.00 s = .

Finished in 0.000745s, 5368.7897 runs/s, 12079.7767 assertions/s.

4 runs, 9 assertions, 0 failures, 0 errors, 0 skips
```

After this change:
```
Run options: -v --seed 56380

ActionableErrorTest#test_returns_no_actions_for_non-actionable_errors = 0.00 s = .
ActionableErrorTest#test_cannot_dispatch_missing_actions = 0.00 s = .
ActionableErrorTest#test_dispatches_actions_from_error_and_name = 0.00 s = .
ActionableErrorTest#test_returns_all_action_of_an_actionable_error = 0.00 s = .

Finished in 0.000752s, 5318.6605 runs/s, 11966.9862 assertions/s.

4 runs, 9 assertions, 0 failures, 0 errors, 0 skips
```

Maybe [this comment](https://github.com/kern/minitest-reporters/issues/247#issuecomment-511932378) of #247 is related.