### PR TITLE
Delete MeanTimeReporter previous run file when resetting

### DIFF
--- a/lib/minitest/reporters/mean_time_reporter.rb
+++ b/lib/minitest/reporters/mean_time_reporter.rb
@@ -100,7 +100,7 @@ module Minitest
       #
       # @return [void]
       def reset_statistics!
-        File.open(previous_runs_filename, 'w+') { |f| f.write('') }
+        File.delete(previous_runs_filename) if File.exist?(previous_runs_filename)
       end
 
       protected


### PR DESCRIPTION
The MeanTimeReporter assumes that if the file exists it has the data of previous
test runs that can be loaded and referenced. Deleting the file instead of
changing the previously_ran? logic seems a little simpler.