### PR TITLE
Remove debug output from ProgressReporter

### DIFF
--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -87,8 +87,7 @@ module Minitest
       end
 
       def print_test_with_time(test)
-        puts [test.name, test_class(test), total_time].inspect
-        print(" %s#%s (%.2fs)" % [test.name, test_class(test), total_time])
+        print(" %s#%s (%.2fs)" % [test_class(test), test.name, total_time])
       end
 
       def color

--- a/test/integration/reporters/progress_reporter_test.rb
+++ b/test/integration/reporters/progress_reporter_test.rb
@@ -6,17 +6,17 @@ module MinitestReportersTest
       fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
       test_filename = File.join(fixtures_directory, 'progress_test.rb')
       output = `#{ruby_executable} #{test_filename} 2>&1`
-      assert_match 'ERROR["test_error"', output, 'Errors should be displayed'
-      assert_match 'FAIL["test_failure"', output, 'Failures should be displayed'
-      assert_match 'SKIP["test_skip', output, 'Skipped tests should be displayed'
+      assert_match 'test_error', output, 'Errors should be displayed'
+      assert_match 'test_failure', output, 'Failures should be displayed'
+      assert_match 'test_skip', output, 'Skipped tests should be displayed'
     end
     def test_skipped_tests_are_not_displayed
       fixtures_directory = File.expand_path('../../../fixtures', __FILE__)
       test_filename = File.join(fixtures_directory, 'progress_detailed_skip_test.rb')
       output = `#{ruby_executable} #{test_filename} 2>&1`
-      assert_match 'ERROR["test_error"', output, 'Errors should be displayed'
-      assert_match 'FAIL["test_failure"', output, 'Failures should be displayed'
-      refute_match 'SKIP["test_skip', output, 'Skipped tests should not be displayed'
+      assert_match 'test_error', output, 'Errors should be displayed'
+      assert_match 'test_failure', output, 'Failures should be displayed'
+      refute_match 'test_skip', output, 'Skipped tests should not be displayed'
     end
     def test_progress_works_with_filter_and_specs
       fixtures_directory = File.expand_path('../../../fixtures', __FILE__)


### PR DESCRIPTION
I noticed that the ProgressReporter was debugging details about failed tests twice: one time as  inspected array, then as proper string. Also, the class name and test name were reversed. I suspect the inspected array was a debug statement that accidentally was left in place.

I removed the debug print statement, and fixed the order of the test class and method name to be `Suite#test_method`.