### PR TITLE
Small spelling fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To override this behavior, you may set the ENV variable MINITEST_REPORTER:
 export MINITEST_REPORTER=JUnitReporter
 ```
 
-Detection of those systems is based on presence of certain ENV variables and are evaulated in the following order:
+Detection of those systems is based on presence of certain ENV variables and are evaluated in the following order:
 
 ```
  MINITEST_REPORTER => use reporter indicated in env variable


### PR DESCRIPTION
* `evaulated` => `evaluated`